### PR TITLE
Use consistent naming for all service page types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Local Government. A part of the LocalGovDrupal distribution.
 Content types:
 
  * Landing page - the top level section for each service;
- * Sub landing page - detail and links to specific pages within a service;
+ * Sub-landing page - detail and links to specific pages within a service;
  * Page - the basic page that can be placed in a service, and on a service
- sub landing page.
+ sub-landing page.
 
  * Status - an optional additional type for providing updates about a the
  status of a service.
 
 Other content types in the LocalGovDrupal distribution can also optionally
-be linked into service sections, and referenced from sublanding pages.
+be linked into service sections, and referenced from sub-landing pages.

--- a/config/install/node.type.localgov_services_landing.yml
+++ b/config/install/node.type.localgov_services_landing.yml
@@ -3,7 +3,7 @@ status: true
 dependencies: { }
 name: 'Service landing page'
 type: localgov_services_landing
-description: ''
+description: 'Top level section page for each service.'
 help: ''
 new_revision: true
 preview_mode: 0

--- a/modules/localgov_services_page/config/install/node.type.localgov_services_page.yml
+++ b/modules/localgov_services_page/config/install/node.type.localgov_services_page.yml
@@ -10,9 +10,9 @@ third_party_settings:
       - about-this-website
       - main
     parent: 'about-this-website:'
-name: 'Services page'
+name: 'Service page'
 type: localgov_services_page
-description: ''
+description: 'Basic page that can be placed in a service and on a service sub landing page.'
 help: ''
 new_revision: true
 preview_mode: 0

--- a/modules/localgov_services_sublanding/config/install/node.type.localgov_services_sublanding.yml
+++ b/modules/localgov_services_sublanding/config/install/node.type.localgov_services_sublanding.yml
@@ -1,9 +1,9 @@
 langcode: en
 status: true
 dependencies: { }
-name: 'Services Sublanding Page'
+name: 'Service sub-landing page'
 type: localgov_services_sublanding
-description: ''
+description: 'Pages for detail and links to specific pages within a service.'
 help: ''
 new_revision: true
 preview_mode: 0


### PR DESCRIPTION
Closes #26