### PR TITLE
Ensure all service page elements display correctly

### DIFF
--- a/localgov_services.info.yml
+++ b/localgov_services.info.yml
@@ -1,6 +1,6 @@
 name: 'LocalGov Services: Core'
 description: Base module shared for LocalGov Services. It won't do anything on its own. Enable LocalGov Services Landing page module.
-core: 8.x
+core_version_requirement: ^8.9 || ^9
 type: module
 package: LocalGovDrupal
 

--- a/modules/localgov_services_landing/config/install/core.entity_view_display.node.localgov_services_landing.default.yml
+++ b/modules/localgov_services_landing/config/install/core.entity_view_display.node.localgov_services_landing.default.yml
@@ -36,26 +36,19 @@ content:
     third_party_settings: {  }
     region: content
   field_address:
-    weight: 6
+    weight: 4
     label: hidden
     settings: {  }
     third_party_settings: {  }
     type: text_default
     region: content
   field_address_first_line:
-    weight: 5
+    weight: 3
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
     type: string
-    region: content
-  field_common_tasks:
-    weight: 8
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
-    type: button_inside_well
     region: content
   field_destinations:
     weight: 1
@@ -67,7 +60,7 @@ content:
     type: entity_reference_entity_view
     region: content
   field_email_address:
-    weight: 2
+    weight: 5
     label: hidden
     settings:
       link_to_entity: false
@@ -76,14 +69,14 @@ content:
     region: content
   field_facebook:
     type: string
-    weight: 9
+    weight: 7
     region: content
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
   field_hearing_difficulties_phone:
-    weight: 11
+    weight: 10
     label: hidden
     settings:
       link_to_entity: false
@@ -91,19 +84,19 @@ content:
     type: string
     region: content
   field_link_to_map:
-    weight: 7
+    weight: 9
     label: hidden
     settings:
       trim_length: 80
-      url_only: true
-      url_plain: true
-      rel: '0'
-      target: '0'
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
     third_party_settings: {  }
     type: link
     region: content
   field_opening_hours:
-    weight: 4
+    weight: 2
     label: hidden
     settings: {  }
     third_party_settings: {  }
@@ -111,15 +104,15 @@ content:
     region: content
   field_phone:
     type: string
-    weight: 3
+    weight: 6
     region: content
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
   field_popular_topics:
-    weight: 12
-    label: above
+    weight: 11
+    label: hidden
     settings:
       title: 'Popular topics'
     third_party_settings: {  }
@@ -127,7 +120,7 @@ content:
     region: content
   field_twitter:
     type: string
-    weight: 10
+    weight: 8
     region: content
     label: hidden
     settings:
@@ -135,6 +128,7 @@ content:
     third_party_settings: {  }
 hidden:
   content_moderation_control: true
+  field_common_tasks: true
   field_contact_us_online: true
   field_other_team_contacts: true
   links: true

--- a/modules/localgov_services_landing/config/install/core.entity_view_display.node.localgov_services_landing.default.yml
+++ b/modules/localgov_services_landing/config/install/core.entity_view_display.node.localgov_services_landing.default.yml
@@ -6,19 +6,21 @@ dependencies:
     - field.field.node.localgov_services_landing.field_address
     - field.field.node.localgov_services_landing.field_address_first_line
     - field.field.node.localgov_services_landing.field_common_tasks
+    - field.field.node.localgov_services_landing.field_contact_us_online
     - field.field.node.localgov_services_landing.field_destinations
     - field.field.node.localgov_services_landing.field_email_address
     - field.field.node.localgov_services_landing.field_facebook
     - field.field.node.localgov_services_landing.field_hearing_difficulties_phone
     - field.field.node.localgov_services_landing.field_link_to_map
     - field.field.node.localgov_services_landing.field_opening_hours
+    - field.field.node.localgov_services_landing.field_other_team_contacts
     - field.field.node.localgov_services_landing.field_phone
     - field.field.node.localgov_services_landing.field_popular_topics
     - field.field.node.localgov_services_landing.field_twitter
     - node.type.localgov_services_landing
   module:
-    - localgov_services_landing
     - link
+    - localgov_services_landing
     - text
     - user
 id: node.localgov_services_landing.default
@@ -34,29 +36,29 @@ content:
     third_party_settings: {  }
     region: content
   field_address:
-    weight: 4
+    weight: 6
     label: hidden
     settings: {  }
     third_party_settings: {  }
     type: text_default
     region: content
   field_address_first_line:
-    weight: 11
-    label: above
+    weight: 5
+    label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
     type: string
     region: content
   field_common_tasks:
-    weight: 6
+    weight: 8
     label: hidden
     settings: {  }
     third_party_settings: {  }
     type: button_inside_well
     region: content
   field_destinations:
-    weight: 7
+    weight: 1
     label: hidden
     settings:
       view_mode: teaser
@@ -65,8 +67,8 @@ content:
     type: entity_reference_entity_view
     region: content
   field_email_address:
-    weight: 10
-    label: above
+    weight: 2
+    label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
@@ -74,50 +76,58 @@ content:
     region: content
   field_facebook:
     type: string
-    weight: 8
+    weight: 9
     region: content
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
   field_hearing_difficulties_phone:
-    weight: 12
-    label: above
+    weight: 11
+    label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
     type: string
     region: content
   field_link_to_map:
-    weight: 13
-    label: above
+    weight: 7
+    label: hidden
     settings:
       trim_length: 80
-      url_only: false
-      url_plain: false
-      rel: ''
-      target: ''
+      url_only: true
+      url_plain: true
+      rel: '0'
+      target: '0'
     third_party_settings: {  }
     type: link
     region: content
   field_opening_hours:
-    weight: 3
+    weight: 4
     label: hidden
     settings: {  }
     third_party_settings: {  }
     type: text_default
     region: content
-  field_popular_topics:
-    weight: 5
+  field_phone:
+    type: string
+    weight: 3
+    region: content
     label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  field_popular_topics:
+    weight: 12
+    label: above
     settings:
       title: 'Popular topics'
     third_party_settings: {  }
-    type: entity_reference_vertical_list
+    type: taxonomy_vertical_list
     region: content
   field_twitter:
     type: string
-    weight: 9
+    weight: 10
     region: content
     label: hidden
     settings:
@@ -125,5 +135,6 @@ content:
     third_party_settings: {  }
 hidden:
   content_moderation_control: true
-  field_phone: true
+  field_contact_us_online: true
+  field_other_team_contacts: true
   links: true

--- a/modules/localgov_services_landing/config/schema/localgov_services_landing.schema.yml
+++ b/modules/localgov_services_landing/config/schema/localgov_services_landing.schema.yml
@@ -6,12 +6,10 @@ field.formatter.settings.twitter_feed:
   type: field.formatter.settings.link
   label: 'Link format twitter feed'
 
-field.formatter.settings.entity_reference_vertical_list:
+field.formatter.settings.taxonomy_vertical_list:
   type: mapping
-  label: 'Entity reference vertical list'
+  label: 'Taxonomy vertical list'
   mapping:
     title:
       type: string
       label: 'List title'
-
-

--- a/modules/localgov_services_landing/localgov_services_landing.info.yml
+++ b/modules/localgov_services_landing/localgov_services_landing.info.yml
@@ -1,6 +1,6 @@
 name: 'LocalGov Services: Landing page'
 description: Top level Services.
-core: 8.x
+core_version_requirement: ^8.9 || ^9
 type: module
 package: LocalGovDrupal
 
@@ -11,7 +11,7 @@ dependencies:
   - drupal:node
   - drupal:text
   - drupal:user
-  - drupal:views  
+  - drupal:views
   - localgov_services:localgov_services
   - localgov_services:localgov_services_sublanding
   - localgov_services:localgov_services_page

--- a/modules/localgov_services_landing/localgov_services_landing.module
+++ b/modules/localgov_services_landing/localgov_services_landing.module
@@ -15,7 +15,7 @@ function localgov_services_landing_theme($existing, $type, $theme, $path) {
       'base hook' => 'node',
     ],
     'taxonomy_vertical_list' => [
-      'template' => 'entity-reference-vertical-list',
+      'template' => 'taxonomy-vertical-list',
       'variables' => [
         'title' => '',
         'items' => [],

--- a/modules/localgov_services_landing/localgov_services_landing.module
+++ b/modules/localgov_services_landing/localgov_services_landing.module
@@ -5,8 +5,6 @@
  * LocalGovDrupal services landing page module file.
  */
 
-use Drupal\Core\Url;
-
 /**
  * Implements hook_theme().
  */
@@ -24,26 +22,4 @@ function localgov_services_landing_theme($existing, $type, $theme, $path) {
       ],
     ],
   ];
-}
-
-/**
- * Implements hook_preprocess_HOOK().
- */
-function localgov_services_landing_preprocess_node(&$variables) {
-  /** @var \Drupal\Entity\NodeInterface $node */
-  $node = $variables['node'];
-
-  if ($node->bundle() == 'localgov_services_landing' and
-    $variables['view_mode'] == 'full' and
-    Drupal::hasService('localgov_services_status.service_status')
-  ) {
-    $statuses = \Drupal::service('localgov_services_status.service_status')->getStatusForBlock($node);
-    if ($statuses) {
-      $variables['service_updates'] = [
-        '#theme' => 'service_status_block',
-        '#items' => $statuses,
-        '#see_all_link' => Url::fromRoute('status.landing_list', ['node' => $node->id()]),
-      ];
-    }
-  }
 }

--- a/modules/localgov_services_landing/localgov_services_landing.module
+++ b/modules/localgov_services_landing/localgov_services_landing.module
@@ -1,38 +1,49 @@
 <?php
 
 /**
+ * @file
+ * LocalGovDrupal services landing page module file.
+ */
+
+use Drupal\Core\Url;
+
+/**
+ * Implements hook_theme().
+ */
+function localgov_services_landing_theme($existing, $type, $theme, $path) {
+  return [
+    'node__localgov_services_landing__full' => [
+      'template' => 'node--localgov-services-landing--full',
+      'base hook' => 'node',
+    ],
+    'taxonomy_vertical_list' => [
+      'template' => 'entity-reference-vertical-list',
+      'variables' => [
+        'title' => '',
+        'items' => [],
+      ],
+    ],
+  ];
+}
+
+/**
  * Implements hook_preprocess_HOOK().
  */
 function localgov_services_landing_preprocess_node(&$variables) {
   /** @var \Drupal\Entity\NodeInterface $node */
   $node = $variables['node'];
 
-  if ($node->bundle() == 'localgov_services_landing') {
-
-    //
-    // @TODO this is dumping the raw values from the node fields into the
-    // variables available to twig.
-    //  - WHY? Can they not just be accessed "normally"?
-    //  - RENDERED? Are we sanitizing and rendering.
-    //
-    if ($variables['view_mode'] == 'full') {
-      $variables['field_facebook'] = $node->get('field_facebook')->isEmpty() ? '' : $node->get('field_facebook')->first()->getValue()['value'];
-      $variables['field_twitter'] = $node->get('field_twitter')->isEmpty() ? '' : $node->get('field_twitter')->first()->getValue()['value'];
-      $variables['field_phone'] = $node->get('field_phone')->isEmpty() ? '' : $node->get('field_phone')->first()->getValue()['value'];
-      $variables['field_contact_us_online'] = $node->get('field_contact_us_online')->isEmpty() ? '' : $node->get('field_contact_us_online')->first()->getValue()['value'];
-      $variables['field_other_team_contacts'] = $node->get('field_other_team_contacts')->isEmpty() ? '' : $node->get('field_other_team_contacts')->first()->getValue()['value'];
-      $variables['field_hearing_difficulties_phone'] = $node->get('field_hearing_difficulties_phone')->isEmpty() ? '' : $node->get('field_hearing_difficulties_phone')->first()->getValue()['value'];
-      $variables['field_email_address'] = $node->get('field_email_address')->isEmpty() ? '' : $node->get('field_email_address')->first()->getValue()['value'];
-      $variables['field_address_first_line'] = $node->get('field_address_first_line')->isEmpty() ? '' : $node->get('field_address_first_line')->first()->getValue()['value'];
-      $variables['field_link_to_map'] = $node->get('field_link_to_map')->isEmpty() ? '' : $node->get('field_link_to_map')->first()->getValue()['uri'];
-
-      // if ($node->get('field_enable_service_updates')->first()->getValue()) {
-      //   $variables['service_updates'] = [
-      //     '#theme' => 'service_updates_block',
-      //     '#items' => Drupal::service('localgov_services_status.service_updates')->getUpdatesForBlock($node),
-      //     '#see_all_link' => \Drupal\Core\Url::fromRoute('service_update_' . $node->id())
-      //   ];
-      // }
+  if ($node->bundle() == 'localgov_services_landing' and
+    $variables['view_mode'] == 'full' and
+    Drupal::hasService('localgov_services_status.service_status')
+  ) {
+    $statuses = \Drupal::service('localgov_services_status.service_status')->getStatusForBlock($node);
+    if ($statuses) {
+      $variables['service_updates'] = [
+        '#theme' => 'service_status_block',
+        '#items' => $statuses,
+        '#see_all_link' => Url::fromRoute('status.landing_list', ['node' => $node->id()]),
+      ];
     }
   }
 }

--- a/modules/localgov_services_landing/src/Plugin/Field/FieldFormatter/ButtonsInsideWell.php
+++ b/modules/localgov_services_landing/src/Plugin/Field/FieldFormatter/ButtonsInsideWell.php
@@ -4,11 +4,9 @@ namespace Drupal\localgov_services_landing\Plugin\Field\FieldFormatter;
 
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\FormatterBase;
-use Drupal\Core\Language\LanguageInterface;
-use Drupal\link\Plugin\Field\FieldType\LinkItem;
 
 /**
- * Class ButtonsInsideWell
+ * Class ButtonsInsideWell.
  *
  * @package Drupal\localgov_services_landing\Plugin\Field\FieldFormatter
  *
@@ -39,10 +37,11 @@ class ButtonsInsideWell extends FormatterBase {
         '#theme' => 'button',
         '#title' => $item->getValue()['title'],
         '#url' => $item->getUrl(),
-        '#type' => $type
+        '#type' => $type,
       ];
     }
 
     return $elements;
   }
+
 }

--- a/modules/localgov_services_landing/src/Plugin/Field/FieldFormatter/TaxonomyVerticalList.php
+++ b/modules/localgov_services_landing/src/Plugin/Field/FieldFormatter/TaxonomyVerticalList.php
@@ -7,27 +7,27 @@ use Drupal\Core\Field\Plugin\Field\FieldFormatter\EntityReferenceFormatterBase;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
- * Class EntityReferenceVerticalList
+ * Class EntityReferenceVerticalList.
  *
  * @package Drupal\localgov_services_landing\Plugin\Field\FieldFormatter
  *
  * @FieldFormatter(
- *   id = "entity_reference_vertical_list",
+ *   id = "taxonomy_vertical_list",
  *   module = "localgov_services_landing",
- *   label = @Translation("Vertical list"),
+ *   label = @Translation("Taxonomy vertical list"),
  *   field_types = {
  *     "entity_reference"
  *   }
  * )
  */
-class EntityReferenceVerticalList extends EntityReferenceFormatterBase {
+class TaxonomyVerticalList extends EntityReferenceFormatterBase {
 
   /**
    * {@inheritdoc}
    */
   public static function defaultSettings() {
     return [
-      'title' => ''
+      'title' => '',
     ] + parent::defaultSettings();
   }
 
@@ -37,8 +37,8 @@ class EntityReferenceVerticalList extends EntityReferenceFormatterBase {
   public function settingsForm(array $form, FormStateInterface $form_state) {
     $elements['title'] = [
       '#type' => 'textfield',
-      '#title' => t('Title'),
-      '#default_value' => $this->getSetting('title')
+      '#title' => $this->t('Title'),
+      '#default_value' => $this->getSetting('title'),
     ];
 
     return $elements;
@@ -51,10 +51,10 @@ class EntityReferenceVerticalList extends EntityReferenceFormatterBase {
     $summary = [];
 
     if ($this->getSetting('title')) {
-      $summary[] = t('Title: @title', ['@title' => $this->getSetting('title')]);
+      $summary[] = $this->t('Title: @title', ['@title' => $this->getSetting('title')]);
     }
     else {
-      $summary[] = t('No title set');
+      $summary[] = $this->t('No title set');
     }
 
     return $summary;
@@ -65,9 +65,10 @@ class EntityReferenceVerticalList extends EntityReferenceFormatterBase {
    */
   public function viewElements(FieldItemListInterface $items, $langcode) {
     return [
-      '#theme' => 'entity_reference_vertical_list',
+      '#theme' => 'taxonomy_vertical_list',
       '#title' => $this->getSetting('title'),
-      '#items' => $this->getEntitiesToView($items, $langcode)
+      '#items' => $this->getEntitiesToView($items, $langcode),
     ];
   }
+
 }

--- a/modules/localgov_services_landing/src/Plugin/Field/FieldFormatter/TwitterFeed.php
+++ b/modules/localgov_services_landing/src/Plugin/Field/FieldFormatter/TwitterFeed.php
@@ -6,7 +6,7 @@ use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\FormatterBase;
 
 /**
- * Class TwitterFeed
+ * Class TwitterFeed.
  *
  * @package Drupal\localgov_services_landing\Plugin\Field\FieldFormatter
  *
@@ -35,14 +35,15 @@ class TwitterFeed extends FormatterBase {
         '#attributes' => [
           'class' => ['twitter-timeline'],
           'href' => $item->getUrl()->toString(),
-          'height' => 500
+          'height' => 500,
         ],
         '#attached' => [
-          'library' => ['localgov_services_landing/twitter_timeline']
-        ]
+          'library' => ['localgov_services_landing/twitter_timeline'],
+        ],
       ];
     }
 
     return $elements;
   }
+
 }

--- a/modules/localgov_services_landing/templates/node--localgov-services-landing--full.html.twig
+++ b/modules/localgov_services_landing/templates/node--localgov-services-landing--full.html.twig
@@ -1,0 +1,110 @@
+{#
+/**
+ * @file
+ * Default node template for localgov_services_landing pages.
+ */
+#}
+{%
+  set classes = [
+    'node',
+    'node--type-' ~ node.bundle|clean_class,
+    node.isPromoted() ? 'node--promoted',
+    node.isSticky() ? 'node--sticky',
+    not node.isPublished() ? 'node--unpublished',
+    view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
+    'row',
+    'servicehub--contact'
+  ]
+%}
+
+{% if content.field_destinations %}
+<section class="container-fluid site-max servicehub--more">
+  {{ content.field_destinations }}
+</section>
+{% endif %}
+
+{% if service_updates %}
+{{ service_updates }}
+{% endif %}
+
+<div class="container-fluid site-max">
+  <article{{ attributes.addClass(classes) }}>
+
+    {% if content.field_email_address|render or content.field_address|render or content.field_opening_hours|render or content.field_phone|render %}
+    <div class="col-md-8">
+      <div class="contact-container">
+        <div class="contact-top">
+          <h2>Contact this service</h2>
+          <div class="row">
+
+            <div class="col-sm-6">
+              <ul>
+                {% if content.field_email_address|render %}
+                <li>
+                  <span class="fa fa-envelope"></span>
+                  <a href="mailto:{{ content.field_email_address|render|striptags }}">Send us a message</a>
+                </li>
+                {% endif %}
+
+                {% if content.field_phone|render|striptags %}
+                <li>
+                  <span class="fa fa-phone"></span>
+                  {{ content.field_phone|render|striptags }}
+                </li>
+                {% endif %}
+              </ul>
+
+              {% if content.field_opening_hours|render %}
+              <p class="opening-times">
+                <h3>Opening times</h3>
+                {{ content.field_opening_hours }}
+              </p>
+              {% endif %}
+            </div>
+
+            <div class="col-sm-6">
+              {% if content.field_address_first_line %}
+              <span class="contact-title"><i class="fa fa-map-marker-alt" aria-hidden="true"></i>{{ content.field_address_first_line }}</span>
+              {% endif %}
+              {% if content.field_address %}
+              <div class="contact-address">
+                {{ content.field_address }}
+                {% if content.field_link_to_map|render|striptags %}
+                <a href="{{ content.field_link_to_map|render|striptags }}" class="external-link" target="_blank">View map</a>
+                {% endif %}
+              </div>
+              {% endif %}
+            </div>
+
+          </div>
+        </div>
+
+        {% if content.field_facebook|render or content.field_twitter|render or content.field_hearing_difficulties_phone|render %}
+        <div class="contact-bottom">
+          {% if content.field_facebook|render or content.field_twitter|render %}
+          <ul>
+            <li>Find us on</li>
+            {% if content.field_facebook|render %}<li><i class="fab fa-facebook-square" aria-hidden="true"></i><a href="{{ content.field_facebook|render|striptags }}">Facebook</a></li>{% endif %}
+            {% if content.field_twitter|render %}<li><i class="fab fa-twitter-square" aria-hidden="true"></i><a href="{{ content.field_twitter|render|striptags }}">Twitter</a></li>{% endif %}
+          </ul>
+          {% endif %}
+          {% if content.field_hearing_difficulties_phone %}
+          <p>If you have hearing or speech difficulties, please call <strong>{{ content.field_hearing_difficulties_phone }}</strong></p>
+          {% endif %}
+        </div>
+        {% endif %}
+
+      </div>
+    </div>
+    {% endif %}
+
+    {% if content.field_popular_topics['#items'] is not empty %}
+    <div class="sidebar col-sm-4">
+      <div class="section">
+        {{ content.field_popular_topics }}
+      </div>
+    </div>
+    {% endif %}
+
+  </article>
+</div>

--- a/modules/localgov_services_landing/templates/taxonomy-vertical-list.html.twig
+++ b/modules/localgov_services_landing/templates/taxonomy-vertical-list.html.twig
@@ -1,0 +1,9 @@
+<h2 class="bhcc-underline">{{ title }}</h2>
+
+<ul>
+  {% for item in items %}
+  <li>
+    <a href="{{ path("entity.taxonomy_term.canonical", {'taxonomy_term': item.id}) }}">{{ item.getName }}</a>
+  </li>
+  {% endfor %}
+</ul>

--- a/modules/localgov_services_landing/templates/taxonomy-vertical-list.html.twig
+++ b/modules/localgov_services_landing/templates/taxonomy-vertical-list.html.twig
@@ -1,5 +1,4 @@
-<h2 class="bhcc-underline">{{ title }}</h2>
-
+<h2>{{ title }}</h2>
 <ul>
   {% for item in items %}
   <li>

--- a/modules/localgov_services_landing/tests/src/Functional/ServicesLandingPageTest.php
+++ b/modules/localgov_services_landing/tests/src/Functional/ServicesLandingPageTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Drupal\Tests\localgov_services_landing\Functional;
+
+use Drupal\node\NodeInterface;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+
+/**
+ * Tests localgov service landing pages.
+ *
+ * @group localgov_services
+ */
+class ServicesLandingPageTest extends BrowserTestBase {
+
+  use NodeCreationTrait;
+
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'field_ui',
+    'localgov_services_landing',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->adminUser = $this->drupalCreateUser([
+      'access administration pages',
+      'administer node fields',
+    ]);
+  }
+
+  /**
+   * Test necessary fields exist and display correctly.
+   */
+  public function testServiceLandingPage() {
+    $this->drupalLogin($this->adminUser);
+
+    // Check all fields exist.
+    $this->drupalGet('/admin/structure/types/manage/localgov_services_landing/fields');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains('body');
+    $this->assertSession()->pageTextContains('field_address');
+    $this->assertSession()->pageTextContains('field_address_first_line');
+    $this->assertSession()->pageTextContains('field_common_tasks');
+    $this->assertSession()->pageTextContains('field_contact_us_online');
+    $this->assertSession()->pageTextContains('field_destinations');
+    $this->assertSession()->pageTextContains('field_email_address');
+    $this->assertSession()->pageTextContains('field_facebook');
+    $this->assertSession()->pageTextContains('field_hearing_difficulties_phone');
+    $this->assertSession()->pageTextContains('field_link_to_map');
+    $this->assertSession()->pageTextContains('field_opening_hours');
+    $this->assertSession()->pageTextContains('field_other_team_contacts');
+    $this->assertSession()->pageTextContains('field_phone');
+    $this->assertSession()->pageTextContains('field_popular_topics');
+    $this->assertSession()->pageTextContains('field_twitter');
+
+    // Check basic landing page.
+    $title = $this->randomMachineName(8);
+    $summary = $this->randomMachineName(16);
+    $page = $this->createNode([
+      'type' => 'localgov_services_landing',
+      'title' => $title,
+      'body' => [
+        'summary' => $summary,
+        'value' => '',
+      ],
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+    $this->drupalGet('/node/' . $page->id());
+    $this->assertSession()->pageTextContains($title);
+    $this->assertSession()->pageTextNotContains('Contact this service');
+    $this->assertSession()->pageTextNotContains('Popular topics');
+
+    // Check child pages.
+    $child = [];
+    for ($i = 1; $i <= 2; $i++) {
+      $child[] = $this->createNode([
+        'type' => 'localgov_services_page',
+        'title' => 'Test service page ' . $i,
+        'body' => [
+          'summary' => 'Test services page summary ' . $i,
+          'value' => '',
+        ],
+        'status' => NodeInterface::PUBLISHED,
+        'path' => ['alias' => '/test-' . $i],
+      ]);
+    }
+    $page->field_destinations->appendItem($child[0]);
+    $page->field_destinations->appendItem($child[1]);
+    $page->save();
+    $this->drupalGet('/node/' . $page->id());
+    for ($i = 1; $i <= 2; $i++) {
+      $this->assertSession()->pageTextContains('Test service page ' . $i);
+      $this->assertSession()->pageTextContains('Test services page summary ' . $i);
+    }
+
+    // Check contact area.
+    $page->set('field_phone', ['value' => '1234567890']);
+    $page->save();
+    $this->drupalGet('/node/' . $page->id());
+    $this->assertSession()->pageTextContains('Contact this service');
+    $this->assertSession()->pageTextContains('1234567890');
+
+    // Check popular topics.
+    $topic_name = $this->randomMachineName(8);
+    $topic = Term::create([
+      'name' => $topic_name,
+      'vid' => 'topic',
+    ]);
+    $topic->save();
+    $page->set('field_popular_topics', ['target_id' => $topic->id()]);
+    $page->save();
+    $this->drupalGet('/node/' . $page->id());
+    $this->assertSession()->pageTextContains('Popular topics');
+    $this->assertSession()->pageTextContains($topic_name);
+  }
+
+}

--- a/modules/localgov_services_navigation/localgov_services_navigation.info.yml
+++ b/modules/localgov_services_navigation/localgov_services_navigation.info.yml
@@ -1,10 +1,10 @@
 name: 'LocalGov Services: Navigation'
 description: Navigation shared by Services Pages, and external pages that link into Services.
-core: 8.x
+core_version_requirement: ^8.9 || ^9
 type: module
 package: LocalGovDrupal
 
 dependencies:
-  - link
-  - node
-  - localgov_services
+  - drupal:link
+  - drupal:node
+  - localgov_services:localgov_services

--- a/modules/localgov_services_page/config/install/core.entity_view_display.node.localgov_services_page.default.yml
+++ b/modules/localgov_services_page/config/install/core.entity_view_display.node.localgov_services_page.default.yml
@@ -38,14 +38,6 @@ content:
     third_party_settings: {  }
     type: entity_reference_entity_view
     region: content
-  localgov_services_parent:
-    weight: 2
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
 hidden:
   content_moderation_control: true
   field_all_topics: true
@@ -57,4 +49,5 @@ hidden:
   field_related_links: true
   field_topic_term: true
   links: true
+  localgov_services_parent: true
   search_api_excerpt: true

--- a/modules/localgov_services_page/localgov_services_page.info.yml
+++ b/modules/localgov_services_page/localgov_services_page.info.yml
@@ -1,6 +1,6 @@
 name: 'LocalGov Services: Page'
 description: Basic page content within a service.
-core: 8.x
+core_version_requirement: ^8.9 || ^9
 type: module
 package: LocalGovDrupal
 

--- a/modules/localgov_services_page/src/Plugin/Block/ServicesRelatedLinksBlock.php
+++ b/modules/localgov_services_page/src/Plugin/Block/ServicesRelatedLinksBlock.php
@@ -27,8 +27,7 @@ class ServicesRelatedLinksBlock extends ServicesBlockBase implements ContainerFa
   public function build() {
     $build = [];
 
-    // @todo Replace the empty array below with $this->buildAutomated().
-    $links = $this->getShouldUseManual() ? $this->buildManual() : [];
+    $links = $this->getShouldUseManual() ? $this->buildManual() : $this->buildAutomated();
 
     if ($links) {
       $build[] = [
@@ -66,10 +65,16 @@ class ServicesRelatedLinksBlock extends ServicesBlockBase implements ContainerFa
   /**
    * Automatically builds a list of links based on the most relevant pages.
    *
+   * @todo Decide how the automated link generation should work.
+   *
    * @return array
    *   Array of links.
    */
   private function buildAutomated() {
+    // Return an empty array for the time being.
+    return [];
+
+    // @codingStandardsIgnoreStart
     // Convert topics field into an array we can use in the query.
     $topics = [];
 
@@ -106,6 +111,7 @@ class ServicesRelatedLinksBlock extends ServicesBlockBase implements ContainerFa
     }
 
     return [];
+    // @codingStandardsIgnoreEnd
   }
 
   /**

--- a/modules/localgov_services_page/tests/src/Functional/ServicesPageTest.php
+++ b/modules/localgov_services_page/tests/src/Functional/ServicesPageTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Drupal\Tests\localgov_services_page\Functional;
+
+use Drupal\node\NodeInterface;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+
+/**
+ * Tests localgov services pages.
+ *
+ * @group localgov_services
+ */
+class ServicesPageTest extends BrowserTestBase {
+
+  use NodeCreationTrait;
+
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'field_ui',
+    'localgov_services_page',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->adminUser = $this->drupalCreateUser([
+      'access administration pages',
+      'administer node fields',
+    ]);
+  }
+
+  /**
+   * Test necessary fields exist and display correctly.
+   */
+  public function testServicesPage() {
+    $this->drupalLogin($this->adminUser);
+
+    // Check all fields exist.
+    $this->drupalGet('/admin/structure/types/manage/localgov_services_page/fields');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains('body');
+    $this->assertSession()->pageTextContains('field_common_tasks');
+    $this->assertSession()->pageTextContains('field_hide_related_topics');
+    $this->assertSession()->pageTextContains('field_page_components');
+    $this->assertSession()->pageTextContains('field_related_links');
+    $this->assertSession()->pageTextContains('field_override_related_links');
+    $this->assertSession()->pageTextContains('field_topic_term');
+    $this->assertSession()->pageTextContains('localgov_services_parent');
+
+    // Check status page.
+    $title = $this->randomMachineName(8);
+    $summary = $this->randomMachineName(16);
+    $body = $this->randomMachineName(32);
+    $page = $this->createNode([
+      'type' => 'localgov_services_page',
+      'title' => $title,
+      'body' => [
+        'summary' => $summary,
+        'value' => $body,
+      ],
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+    $this->drupalGet('/node/' . $page->id());
+    $this->assertSession()->pageTextContains($title);
+    $this->assertSession()->pageTextContains($body);
+  }
+
+}

--- a/modules/localgov_services_status/config/install/core.entity_view_display.node.localgov_services_status.default.yml
+++ b/modules/localgov_services_status/config/install/core.entity_view_display.node.localgov_services_status.default.yml
@@ -3,13 +3,12 @@ status: true
 dependencies:
   config:
     - field.field.node.localgov_services_status.body
-    - field.field.node.localgov_services_status.localgov_services_parent
     - field.field.node.localgov_services_status.field_service_status
     - field.field.node.localgov_services_status.field_service_status_on_landing
     - field.field.node.localgov_services_status.field_service_status_on_list
+    - field.field.node.localgov_services_status.localgov_services_parent
     - node.type.localgov_services_status
   module:
-    - options
     - text
     - user
 id: node.localgov_services_status.default
@@ -20,25 +19,15 @@ content:
   body:
     label: hidden
     type: text_default
-    weight: 1
-    settings: {  }
-    third_party_settings: {  }
-    region: content
-  field_service_status:
-    weight: 2
-    label: above
-    settings: {  }
-    third_party_settings: {  }
-    type: list_default
-    region: content
-  links:
     weight: 0
-    region: content
     settings: {  }
     third_party_settings: {  }
+    region: content
 hidden:
   content_moderation_control: true
-  localgov_services_parent: true
+  field_service_status: true
   field_service_status_on_landing: true
   field_service_status_on_list: true
+  links: true
+  localgov_services_parent: true
   search_api_excerpt: true

--- a/modules/localgov_services_status/config/install/field.field.node.localgov_services_status.body.yml
+++ b/modules/localgov_services_status/config/install/field.field.node.localgov_services_status.body.yml
@@ -6,7 +6,6 @@ dependencies:
     - node.type.localgov_services_status
   module:
     - text
-third_party_settings: {  }
 id: node.localgov_services_status.body
 field_name: body
 entity_type: node
@@ -19,5 +18,5 @@ default_value: {  }
 default_value_callback: ''
 settings:
   display_summary: true
-  required_summary: false
+  required_summary: true
 field_type: text_with_summary

--- a/modules/localgov_services_status/config/optional/pathauto.pattern.localgov_service_status.yml
+++ b/modules/localgov_services_status/config/optional/pathauto.pattern.localgov_service_status.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: localgov_service_status
+label: 'Service Status Page'
+type: 'canonical_entities:node'
+pattern: '[node:localgov_services_parent:entity:url:relative]/[node:title]'
+selection_criteria:
+  fb899c5a-41f3-4482-9b7d-7f203c4290c4:
+    id: node_type
+    bundles:
+      localgov_services_status: localgov_services_status
+    negate: false
+    context_mapping:
+      node: node
+    uuid: fb899c5a-41f3-4482-9b7d-7f203c4290c4
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/modules/localgov_services_status/localgov_services_status.info.yml
+++ b/modules/localgov_services_status/localgov_services_status.info.yml
@@ -2,7 +2,7 @@ name: 'LocalGovDrupal Services: Status page'
 description: 'Status updates related to a service landing page.'
 package: LocalGovDrupal
 type: module
-core_version_requirement: ^8.8 || ^9
+core_version_requirement: ^8.9 || ^9
 
 dependencies:
   - drupal:options

--- a/modules/localgov_services_status/localgov_services_status.module
+++ b/modules/localgov_services_status/localgov_services_status.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 
 /**
@@ -36,6 +37,25 @@ function localgov_services_status_node_presave(NodeInterface $entity) {
     if (!$entity->get('localgov_services_parent')->isEmpty()) {
       $invalidate_node_id = $entity->get('localgov_services_parent')->first()->getValue()['target_id'];
       Cache::invalidateTags(['node:' . $invalidate_node_id]);
+    }
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function localgov_services_status_preprocess_node(&$variables) {
+  /** @var \Drupal\Entity\NodeInterface $node */
+  $node = $variables['node'];
+
+  if ($node->bundle() == 'localgov_services_landing' and $variables['view_mode'] == 'full') {
+    $statuses = \Drupal::service('localgov_services_status.service_status')->getStatusForBlock($node);
+    if ($statuses) {
+      $variables['service_updates'] = [
+        '#theme' => 'service_status_block',
+        '#items' => $statuses,
+        '#see_all_link' => Url::fromRoute('status.landing_list', ['node' => $node->id()]),
+      ];
     }
   }
 }

--- a/modules/localgov_services_status/localgov_services_status.module
+++ b/modules/localgov_services_status/localgov_services_status.module
@@ -24,9 +24,6 @@ function localgov_services_status_theme($existing, $type, $theme, $path) {
         'items' => [],
       ],
     ],
-    'service_status' => [
-      'render element' => 'block',
-    ],
   ];
 }
 

--- a/modules/localgov_services_status/src/Controller/ServiceStatusPageController.php
+++ b/modules/localgov_services_status/src/Controller/ServiceStatusPageController.php
@@ -54,7 +54,7 @@ class ServiceStatusPageController extends ControllerBase {
   public function access(NodeInterface $node): AccessResult {
     return AccessResult::allowedIf(
       $node->bundle() == 'localgov_services_landing' &&
-      $this->serviceStatus->statusUpdateCount($node, TRUE)
+      $this->serviceStatus->statusUpdateCount($node, TRUE, FALSE)
     );
   }
 

--- a/modules/localgov_services_status/src/ServiceStatus.php
+++ b/modules/localgov_services_status/src/ServiceStatus.php
@@ -145,12 +145,16 @@ class ServiceStatus {
    *   Partly prepared Entity Query.
    */
   protected function statusUpdatesQuery($landing_nid, $hide_from_list) {
-    return $this->entityTypeManager->getStorage('node')->getQuery()
+    $query = $this->entityTypeManager->getStorage('node')->getQuery()
       ->condition('type', 'localgov_services_status')
       ->condition('localgov_services_parent', $landing_nid)
-      ->condition('field_service_status_on_list', $hide_from_list)
       ->condition('status', NodeInterface::PUBLISHED)
       ->addTag('node_access');
+    if ($hide_from_list) {
+      $query->condition('field_service_status_on_list', 1);
+    }
+
+    return $query;
   }
 
 }

--- a/modules/localgov_services_status/src/ServiceStatus.php
+++ b/modules/localgov_services_status/src/ServiceStatus.php
@@ -108,6 +108,7 @@ class ServiceStatus {
 
     $items = [];
     foreach ($service_status as $node) {
+      /** @var \Drupal\node\Entity\Node $node */
       $node = $this->entityRepository->getTranslationFromContext($node);
       $items[] = [
         'date' => $node->getCreatedTime(),

--- a/modules/localgov_services_status/templates/service-status-block.html.twig
+++ b/modules/localgov_services_status/templates/service-status-block.html.twig
@@ -1,23 +1,22 @@
-
 {% if items %}
-  <div class="services-landing--update">
-    <div class="services-landing--status">
-        <span>
-            <i class="fas fa-info-circle"></i>
-            <h3>Service updates</h3>
-        </span>
-        <a href="{{ see_all_link }}" class="hidden-xs action-link pull-right"><i class="action-link--icon fas fa-chevron-right"></i>See all</a>
-    </div>
-
-    <div class="services-landing--update_inner">
-      {% for item in items %}
-      <ul>
-        <li>{{ item.date|date("d.m.Y") }}</li>
-        <li><strong>{{ item.title }} - </strong>{{ item.description }}</li>
-        <li><a class="read-more" href="{{ item.url }}">Read more</a></li>
-      </ul>
-      {% endfor %}
-    </div>
-    <a href="{{ see_all_link }}" class="visible-xs action-link margin-top--20"><i class="action-link--icon fas fa-chevron-right"></i>See all</a>
+<div class="servicehub--update">
+  <div class="servicehub--status">
+      <span>
+          <i class="fas fa-info-circle"></i>
+          <h3>Service updates</h3>
+      </span>
+      <a href="{{ see_all_link }}" class="hidden-xs action-link pull-right"><i class="action-link--icon fas fa-chevron-right"></i>See all</a>
   </div>
+
+  <div class="servicehub--update_inner">
+    {% for item in items %}
+    <ul>
+      <li>{{ item.date|date("d.m.Y") }}</li>
+      <li><strong>{{ item.title }} - </strong>{{ item.description }}</li>
+      <li><a class="read-more" href="{{ item.url }}">Read more</a></li>
+    </ul>
+    {% endfor %}
+  </div>
+  <a href="{{ see_all_link|render }}" class="visible-xs action-link margin-top--20"><i class="action-link--icon fas fa-chevron-right"></i>See all</a>
+</div>
 {% endif %}

--- a/modules/localgov_services_status/templates/service-status-page.html.twig
+++ b/modules/localgov_services_status/templates/service-status-page.html.twig
@@ -1,14 +1,20 @@
-
 {% if items %}
-  <div class="servicehub--update striped">
-    <div class="serviceub--update_inner">
-      {% for item in items %}
-      <ul>
-        <li>{{ item.date|date("d.m.Y") }}</li>
-        <li><strong>{{ item.title }} - </strong>{{ item.description }}</li>
-        <li><a class="read-more" href="{{ item.url }}">Read more</a></li>
-      </ul>
-      {% endfor %}
-    </div>
+<div class="servicehub--update striped">
+  <div class="serviceub--update_inner">
+    {% for item in items %}
+    <ul>
+      <li>{{ item.date|date("d.m.Y") }}</li>
+      <li><strong>{{ item.title }} - </strong>{{ item.description }}</li>
+      <li><a class="read-more" href="{{ item.url }}">Read more</a></li>
+    </ul>
+    {% endfor %}
   </div>
+</div>
+{% else %}
+<div class="servicehub--update">
+  <span>
+    <i class="fas fa-info-circle"></i>
+    <p>There are no current issues with this service</p>
+  </span>
+</div>
 {% endif %}

--- a/modules/localgov_services_status/templates/service-status-page.html.twig
+++ b/modules/localgov_services_status/templates/service-status-page.html.twig
@@ -1,7 +1,7 @@
 
 {% if items %}
-  <div class="services-landing--update striped">
-    <div class="services-landing--update_inner">
+  <div class="servicehub--update striped">
+    <div class="serviceub--update_inner">
       {% for item in items %}
       <ul>
         <li>{{ item.date|date("d.m.Y") }}</li>

--- a/modules/localgov_services_status/templates/service-status.html.twig
+++ b/modules/localgov_services_status/templates/service-status.html.twig
@@ -1,6 +1,0 @@
-<div class="services-landing--status">
-  <span>
-      <i class="fas fa-info-circle"></i>
-      <p>There are no current issues with this service</p>
-  </span>
-</div>

--- a/modules/localgov_services_status/tests/src/Functional/ServiceStatusTest.php
+++ b/modules/localgov_services_status/tests/src/Functional/ServiceStatusTest.php
@@ -52,7 +52,7 @@ class ServiceStatusTest extends BrowserTestBase {
   /**
    * Test necessary fields have been added.
    */
-  public function testServiceStatusFields() {
+  public function testServiceStatusPages() {
     $this->drupalLogin($this->adminUser);
 
     // Check all fields exist.
@@ -72,28 +72,51 @@ class ServiceStatusTest extends BrowserTestBase {
     ]);
 
     // Create a status page.
-    $this->drupalGet('/node/add/localgov_services_status');
-    $edit = [
-      'title[0][value]' => 'Test Status',
-      'body[0][value]' => 'Test status body',
-      'localgov_services_parent' => $landing->id(),
-      'field_service_status' => '0-severe-impact',
-      'field_service_status_on_landing[value]' => 1,
-      'field_service_status_on_list[value]' => 1,
-      'status[value]' => 1,
-    ];
-    $this->drupalPostForm(NULL, $edit, 'Save');
-    $this->assertSession()->pageTextContains('Test Status');
-    $this->assertSession()->pageTextContains('Test status body');
+    $title = $this->randomMachineName(8);
+    $summary = $this->randomMachineName(16);
+    $body = $this->randomMachineName(32);
+    $status = $this->createNode([
+      'type' => 'localgov_services_status',
+      'title' => $title,
+      'body' => [
+        'summary' => $summary,
+        'value' => $body,
+      ],
+      'localgov_services_parent' => ['target_id' => $landing->id()],
+      'field_service_status' => ['value' => '0-severe-impact'],
+      'field_service_status_on_landing' => ['value' => 1],
+      'field_service_status_on_list' => ['value' => 1],
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+    $this->drupalGet('/node/' . $status->id());
+    $this->assertSession()->pageTextContains($title);
+    $this->assertSession()->pageTextContains($body);
 
-    // See a status message on a landing page.
-    // Hide a status message on a landing page.
+    // Check display on landing page.
+    $this->drupalGet('/node/' . $landing->id());
+    $this->assertSession()->pageTextContains($title);
+    $this->assertSession()->pageTextContains($summary);
+    $status->setUnpublished();
+    $status->save();
+    $this->drupalGet('/node/' . $landing->id());
+    $this->assertSession()->pageTextNotContains($title);
+    $this->assertSession()->pageTextNotContains($summary);
+    $status->setPublished();
+    $status->save();
+    $this->drupalGet('/node/' . $landing->id());
+    $this->assertSession()->pageTextContains($title);
+    $this->assertSession()->pageTextContains($summary);
+    $status->set('field_service_status_on_landing', ['value' => 0]);
+    $status->save();
+    $this->drupalGet('/node/' . $landing->id());
+    $this->assertSession()->pageTextNotContains($title);
+    $this->assertSession()->pageTextNotContains($summary);
   }
 
   /**
    * Test listings.
    */
-  public function testServiceListingPages() {
+  public function testServiceStatusListings() {
     $this->drupalLogin($this->adminUser);
 
     // Create a landing page.
@@ -103,15 +126,19 @@ class ServiceStatusTest extends BrowserTestBase {
     ]);
 
     // Create some status updates.
+    $status = [];
     for ($i = 1; $i <= 3; $i++) {
-      $this->createNode([
+      $status[$i] = $this->createNode([
         'type' => 'localgov_services_status',
         'title' => 'Test Status ' . $i,
-        'body' => 'Test service body ' . $i,
-        'localgov_services_parent' => $landing->id(),
-        'field_service_status' => '0-severe-impact',
-        'field_service_status_on_landing' => 1,
-        'field_service_status_on_list' => 1,
+        'body' => [
+          'summary' => 'Test status summary ' . $i,
+          'value' => 'Test status body ' . $i,
+        ],
+        'localgov_services_parent' => ['target_id' => $landing->id()],
+        'field_service_status' => ['value' => '0-severe-impact'],
+        'field_service_status_on_landing' => ['value' => 1],
+        'field_service_status_on_list' => ['value' => 1],
         'status' => NodeInterface::PUBLISHED,
       ]);
     }
@@ -134,10 +161,8 @@ class ServiceStatusTest extends BrowserTestBase {
     $this->assertContains('Test Status 3', $results[2]->getText());
 
     // Check sticky on top works.
-    $edit = [
-      'sticky[value]' => 1,
-    ];
-    $this->drupalPostForm('/node/4/edit', $edit, 'Save');
+    $status[3]->setSticky(TRUE);
+    $status[3]->save();
     $this->drupalGet('/service-status');
     $xpath = '//ul[@id="tabs"]/li/a';
     /** @var \Behat\Mink\Element\NodeElement[] $results */
@@ -147,32 +172,24 @@ class ServiceStatusTest extends BrowserTestBase {
     $this->assertContains('Test Status 2', $results[1]->getText());
 
     // Check unpublish.
-    $edit = [
-      'status[value]' => NodeInterface::NOT_PUBLISHED,
-    ];
-    $this->drupalPostForm('/node/3/edit', $edit, 'Save');
-
+    $status[2]->setUnpublished();
+    $status[2]->save();
     $this->drupalGet('/node/' . $landing->id() . '/status');
     $this->assertSession()->pageTextNotContains('Test Status 2');
     $this->drupalGet('/service-status');
     $this->assertSession()->pageTextNotContains('Test Status 2');
 
     // Check hide from lists.
-    $edit = [
-      'field_service_status_on_list[value]' => 0,
-    ];
-    $this->drupalPostForm('/node/2/edit', $edit, 'Save');
-
+    $status[1]->set('field_service_status_on_list', ['value' => 0]);
+    $status[1]->save();
     $this->drupalGet('/node/' . $landing->id() . '/status');
     $this->assertSession()->pageTextNotContains('Test Status 1');
     $this->drupalGet('/service-status');
     $this->assertSession()->pageTextNotContains('Test Status 1');
 
     // Check service status updates page with no valid statuses.
-    $edit = [
-      'field_service_status_on_list[value]' => 0,
-    ];
-    $this->drupalPostForm('/node/4/edit', $edit, 'Save');
+    $status[3]->set('field_service_status_on_list', ['value' => 0]);
+    $status[3]->save();
     $this->drupalGet('node/' . $landing->id() . '/status');
     $this->assertSession()->statusCodeEquals(403);
   }
@@ -192,11 +209,14 @@ class ServiceStatusTest extends BrowserTestBase {
     $this->createNode([
       'type' => 'localgov_services_status',
       'title' => 'Test Status',
-      'body' => 'Test service body',
-      'localgov_services_parent' => $landing->id(),
-      'field_service_status' => '0-severe-impact',
-      'field_service_status_on_landing' => 1,
-      'field_service_status_on_list' => 1,
+      'body' => [
+        'summary' => 'Test status summary',
+        'value' => 'Test status body',
+      ],
+      'localgov_services_parent' => ['target_id' => $landing->id()],
+      'field_service_status' => ['value' => '0-severe-impact'],
+      'field_service_status_on_landing' => ['value' => 1],
+      'field_service_status_on_list' => ['value' => 1],
       'status' => NodeInterface::PUBLISHED,
     ]);
 

--- a/modules/localgov_services_status/tests/src/Functional/ServiceStatusTest.php
+++ b/modules/localgov_services_status/tests/src/Functional/ServiceStatusTest.php
@@ -7,7 +7,7 @@ use Drupal\Tests\BrowserTestBase;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 
 /**
- * Tests localgov services pages working together, and with external modules.
+ * Tests localgov service status pages.
  *
  * @group localgov_services
  */

--- a/modules/localgov_services_sublanding/config/install/core.entity_view_display.node.localgov_services_sublanding.default.yml
+++ b/modules/localgov_services_sublanding/config/install/core.entity_view_display.node.localgov_services_sublanding.default.yml
@@ -23,15 +23,8 @@ content:
       link: ''
     third_party_settings: {  }
     region: content
-  localgov_services_parent:
-    weight: 1
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
 hidden:
   body: true
   content_moderation_control: true
   links: true
+  localgov_services_parent: true

--- a/modules/localgov_services_sublanding/localgov_services_sublanding.info.yml
+++ b/modules/localgov_services_sublanding/localgov_services_sublanding.info.yml
@@ -1,6 +1,6 @@
 name: 'LocalGov Services: Sub Landing page'
 description: Services second level pages.
-core: 8.x
+core_version_requirement: ^8.9 || ^9
 type: module
 package: LocalGovDrupal
 

--- a/modules/localgov_services_sublanding/localgov_services_sublanding.info.yml
+++ b/modules/localgov_services_sublanding/localgov_services_sublanding.info.yml
@@ -17,5 +17,6 @@ dependencies:
   - localgov_services:localgov_services
   - localgov_services:localgov_services_landing
   - localgov_services:localgov_services_navigation
+  - localgov_services:localgov_services_page
   - localgov_topics:localgov_topics
   - pathauto:pathauto

--- a/modules/localgov_services_sublanding/localgov_services_sublanding.module
+++ b/modules/localgov_services_sublanding/localgov_services_sublanding.module
@@ -1,6 +1,11 @@
 <?php
 
 /**
+ * @file
+ * LocalGovDrupal service sub-landing page module file.
+ */
+
+/**
  * Implements hook_theme().
  */
 function localgov_services_sublanding_theme($existing, $type, $theme, $path) {
@@ -9,18 +14,28 @@ function localgov_services_sublanding_theme($existing, $type, $theme, $path) {
       'render element' => 'element',
       'variables' => [
         'title' => '',
-        'url' => ''
-      ]
-    ]
+        'url' => '',
+      ],
+    ],
+    'field__paragraph__topic_list_links__topic_list_builder' => [
+      'template' => 'field--paragraph--topic-list-links--topic-list-builder',
+      'base hook' => 'field',
+    ],
+    'paragraph__topic_list_builder' => [
+      'template' => 'paragraph--topic-list-builder',
+      'base hook' => 'paragraph',
+    ],
   ];
 }
 
 /**
  * Counts how many nodes are attached to a taxonomy term.
  *
- * @param $tid
+ * @param int $tid
+ *   Taxonomy term ID.
  *
  * @return int
+ *   Number of nodes attached to a taxonomy term.
  */
 function localgov_services_sublanding_count_nodes_with_taxonomy($tid) {
   $query = \Drupal::database()->select('taxonomy_index', 'ti');
@@ -41,27 +56,23 @@ function localgov_services_sublanding_preprocess_paragraph__topic_list_builder(&
   // calculate this. We count how many items we're showing in this paragraph,
   // then count how many nodes the term has to show. If there are more items
   // in the paragraph then items we're showing, we display the 'More' button.
-
-  // Get topic term id and count how many nodes are in the term.
   if (!$paragraph->get('topic_list_term')->isEmpty()) {
     $topic_tid = $paragraph->get('topic_list_term')->first()->getValue()['target_id'];
     $nodes_in_term = localgov_services_sublanding_count_nodes_with_taxonomy($topic_tid);
 
     // Count how many nodes this paragraph has.
     $nodes_in_paragraph = $paragraph->get('topic_list_links')->count();
-
     $variables['show_more'] = ($nodes_in_term > $nodes_in_paragraph);
+    $variables['show_more_path'] = \Drupal::service('path.alias_manager')->getAliasByPath('/taxonomy/term/' . $topic_tid);
   }
 
   // The header text is set by default to the topic entity label but can be
   // overwritten by the topic_list_header field.
-
-  if (!$paragraph->get('topic_list_term')->isEmpty()) {
-    $topic = $paragraph->get('topic_list_term')->entity;
-    $variables['header'] = $topic->label();
-  }
-
   if (!$paragraph->get('topic_list_header')->isEmpty()) {
     $variables['header'] = $paragraph->get('topic_list_header')->first()->getValue()['value'];
+  }
+  elseif (!$paragraph->get('topic_list_term')->isEmpty()) {
+    $topic = $paragraph->get('topic_list_term')->entity;
+    $variables['header'] = $topic->label();
   }
 }

--- a/modules/localgov_services_sublanding/src/Plugin/Field/FieldFormatter/LinkNodeReference.php
+++ b/modules/localgov_services_sublanding/src/Plugin/Field/FieldFormatter/LinkNodeReference.php
@@ -3,16 +3,16 @@
 namespace Drupal\localgov_services_sublanding\Plugin\Field\FieldFormatter;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\FormatterBase;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Url;
 use Drupal\link\Plugin\Field\FieldType\LinkItem;
-use http\Exception\UnexpectedValueException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Class LinkNodeReference
+ * Class LinkNodeReference.
  *
  * @package Drupal\localgov_services_sublanding\Plugin\Field\FieldFormatter
  *
@@ -28,6 +28,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class LinkNodeReference extends FormatterBase implements ContainerFactoryPluginInterface {
 
   /**
+   * Entity type manager service.
+   *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   private $entityTypeManager;
@@ -51,7 +53,7 @@ class LinkNodeReference extends FormatterBase implements ContainerFactoryPluginI
   /**
    * {@inheritdoc}
    */
-  public function __construct($plugin_id, $plugin_definition, \Drupal\Core\Field\FieldDefinitionInterface $field_definition, array $settings, $label, $view_mode, array $third_party_settings, EntityTypeManagerInterface $entityTypeManager) {
+  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, $label, $view_mode, array $third_party_settings, EntityTypeManagerInterface $entityTypeManager) {
     parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
     $this->entityTypeManager = $entityTypeManager;
   }
@@ -77,24 +79,31 @@ class LinkNodeReference extends FormatterBase implements ContainerFactoryPluginI
   /**
    * Build the render array for external links.
    *
-   * @param $item
+   * @param \Drupal\link\Plugin\Field\FieldType\LinkItem $item
+   *   Link item to render.
    *
    * @return array
+   *   Render array.
    */
   private function buildExternal(LinkItem $item) {
     return [
       '#theme' => 'dummy_teaser',
       '#title' => $item->getValue()['title'],
-      '#url' => Url::fromUri($item->getValue()['uri'])
+      '#url' => Url::fromUri($item->getValue()['uri']),
     ];
   }
 
   /**
    * Build the render array for internal links.
    *
-   * @param $item
+   * @param \Drupal\link\Plugin\Field\FieldType\LinkItem $item
+   *   Link item to render.
+   * @param string $langcode
+   *   Language code.
    *
    * @return array
+   *   Render array.
+   *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    */
   private function buildInternal(LinkItem $item, $langcode) {
@@ -106,7 +115,8 @@ class LinkNodeReference extends FormatterBase implements ContainerFactoryPluginI
       if ($entity) {
         $view_builder = $this->entityTypeManager->getViewBuilder($entity->getEntityTypeId());
         return $view_builder->view($entity, 'teaser', $langcode);
-      } else {
+      }
+      else {
         return [];
       }
     }
@@ -115,4 +125,5 @@ class LinkNodeReference extends FormatterBase implements ContainerFactoryPluginI
       return $this->buildExternal($item);
     }
   }
+
 }

--- a/modules/localgov_services_sublanding/templates/dummy-teaser.html.twig
+++ b/modules/localgov_services_sublanding/templates/dummy-teaser.html.twig
@@ -1,5 +1,3 @@
-
-
 <article class="node-teaser">
-  <h2><a href="{{ url }}">{{ title }}</a></h2>
+  <h3><a href="{{ url }}">{{ title }}</a></h3>
 </article>

--- a/modules/localgov_services_sublanding/templates/field--paragraph--topic-list-links--topic-list-builder.html.twig
+++ b/modules/localgov_services_sublanding/templates/field--paragraph--topic-list-links--topic-list-builder.html.twig
@@ -1,0 +1,16 @@
+{#
+/**
+ * @file
+ * Template for topic list builder paragraphs topic list links field.
+#}
+<div{{ attributes.addClass('container-fluid') }}>
+  {% for row in items|batch(2) %}
+  <div class="row">
+    {% for item in row %}
+    <div class="col-sm-6">
+      {{ item.content }}
+    </div>
+    {% endfor %}
+  </div>
+  {% endfor %}
+</div>

--- a/modules/localgov_services_sublanding/templates/paragraph--topic-list-builder.html.twig
+++ b/modules/localgov_services_sublanding/templates/paragraph--topic-list-builder.html.twig
@@ -1,0 +1,15 @@
+{#
+/**
+ * @file
+ * Topic list builder paragraph type.
+ */
+#}
+{% if header %}
+<h2 class="col-12 mb-4">{{ header }}</h2>
+{% endif %}
+{{ content.topic_list_links }}
+{% if show_more %}
+<div class="action-link float-right">
+  <span class="fa fa-chevron-right"></span><a href="{{ show_more_path }}">More</a>
+</div>
+{% endif %}

--- a/modules/localgov_services_sublanding/tests/src/Functional/ServiceSublandingTest.php
+++ b/modules/localgov_services_sublanding/tests/src/Functional/ServiceSublandingTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Drupal\Tests\localgov_services_sublanding\Functional;
+
+use Drupal\node\NodeInterface;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+
+/**
+ * Tests localgov services sub-landing pages.
+ *
+ * @group localgov_services
+ */
+class ServiceSublandingTest extends BrowserTestBase {
+
+  use NodeCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'field_ui',
+    'localgov_services_sublanding',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->adminUser = $this->drupalCreateUser([
+      'access administration pages',
+      'administer content types',
+      'administer node fields',
+    ]);
+  }
+
+  /**
+   * Test necessary fields have been added.
+   */
+  public function testServiceSublandingPages() {
+    $this->drupalLogin($this->adminUser);
+
+    // Check all fields exist.
+    $this->drupalGet('/admin/structure/types/manage/localgov_services_sublanding/fields');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains('body');
+    $this->assertSession()->pageTextContains('field_topics');
+    $this->assertSession()->pageTextContains('localgov_services_parent');
+
+    // Check status page.
+    $title = $this->randomMachineName(8);
+    $summary = $this->randomMachineName(16);
+    $body = $this->randomMachineName(32);
+    $page = $this->createNode([
+      'type' => 'localgov_services_sublanding',
+      'title' => $title,
+      'body' => [
+        'summary' => $summary,
+        'value' => $body,
+      ],
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+    $this->drupalGet('/node/' . $page->id());
+    $this->assertSession()->pageTextContains($title);
+  }
+
+}

--- a/modules/localgov_services_sublanding/tests/src/Functional/TopicListBuilderTest.php
+++ b/modules/localgov_services_sublanding/tests/src/Functional/TopicListBuilderTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Drupal\Tests\localgov_services_sublanding\Functional;
+
+use Drupal\node\NodeInterface;
+use Drupal\paragraphs\Entity\Paragraph;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+
+/**
+ * Tests Topic List Builder Paragraph type.
+ *
+ * @group localgov_services
+ */
+class TopicListBuilderTest extends BrowserTestBase {
+
+  use NodeCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'localgov_services_sublanding',
+  ];
+
+  /**
+   * Test topic list builder functionality.
+   */
+  public function testTopicListBuilderParagraphDisplay() {
+
+    // Create a sub-landing page.
+    $page = $this->createNode([
+      'type' => 'localgov_services_sublanding',
+      'title' => 'Test sub-landing page.',
+      'body' => [
+        'summary' => 'Test sub-landing page text',
+        'value' => '',
+      ],
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+
+    // Check with term and external link.
+    $topic_name = $this->randomMachineName(8);
+    $topic = Term::create([
+      'name' => $topic_name,
+      'vid' => 'topic',
+    ]);
+    $topic->save();
+    $tlb_term = Paragraph::create([
+      'type' => 'topic_list_builder',
+      'topic_list_term' => ['target_id' => $topic->id()],
+      'topic_list_links' => [
+        'uri' => 'https://example.com/',
+        'title' => 'External link text',
+      ],
+    ]);
+    $tlb_term->save();
+    $page->field_topics->appendItem($tlb_term);
+    $page->save();
+    $this->drupalGet('/node/' . $page->id());
+    $this->assertSession()->pageTextContains($topic_name);
+    $this->assertSession()->pageTextContains('External link text');
+    $this->assertSession()->responseContains('href="https://example.com/"');
+
+    // Check with header and link.
+    $service_path = '/' . $this->randomMachineName(8);
+    $this->createNode([
+      'type' => 'localgov_services_page',
+      'title' => 'Test services page',
+      'body' => [
+        'summary' => 'Test services page summary',
+        'value' => 'Test services page text',
+      ],
+      'status' => NodeInterface::PUBLISHED,
+      'path' => ['alias' => $service_path],
+    ]);
+    $header = $this->randomMachineName(12);
+    $tlb_header = Paragraph::create([
+      'type' => 'topic_list_builder',
+      'topic_list_header' => ['value' => $header],
+      'topic_list_links' => [
+        'uri' => 'internal:' . $service_path,
+        'title' => 'Example internal link',
+      ],
+    ]);
+    $tlb_header->save();
+    $page->field_topics->appendItem($tlb_header);
+    $page->save();
+    $this->drupalGet('/node/' . $page->id());
+    $this->assertSession()->pageTextContains($header);
+    $this->assertSession()->pageTextContains('Example internal link');
+    $this->assertSession()->responseContains('href="' . $service_path . '"');
+  }
+
+}

--- a/src/Plugin/Field/FieldWidget/LinkWithType.php
+++ b/src/Plugin/Field/FieldWidget/LinkWithType.php
@@ -30,11 +30,12 @@ class LinkWithType extends LinkWidget {
       '#default_value' => isset($items[$delta]->options['type']) ? $items[$delta]->options['type'] : 'action',
       '#type' => 'select',
       '#options' => [
-        'action' => 'Action',
-        'basic' => 'Information'
-      ]
+        'action' => $this->t('Action'),
+        'basic' => $this->t('Information'),
+      ],
     ];
 
     return $element;
   }
+
 }


### PR DESCRIPTION
This pull request ensures that fields display correctly for the 4 service page content types. It does this by sorting out the preprocess theming hooks and adding / updating templates. I have also fixed all coding standards issues.As such it deals with the following issues:
- https://github.com/localgovdrupal/localgov_services/issues/22
- https://github.com/localgovdrupal/localgov_services/issues/40
- https://github.com/localgovdrupal/localgov_services/issues/43

A couple of things that haven't been done and moved into separate issues:
- I have pretty much moved the templates as is from the theme, we'll likely want to clean up the classes https://github.com/localgovdrupal/localgov_services/issues/47
- The user story for the landing page in Trello (https://trello.com/c/kH5UvU3P/203-as-a-content-designer-create-and-manage-services-landing-page) talks about replacing the contact fields with the contact paragraph type. This could be a fair chunk of work and doesn't seem a high priority right now https://github.com/localgovdrupal/localgov_services/issues/46

To test this you just need to ensure all other repos are on master and then checkout the feature/40-service-templates-and-preprocess-hooks branch on the localgov_services module. There is default content for all of these changes if you enable the localgov_demo module after running a site install. All fields should display as per the user stories in Trello apart from those mentioned above. There are basic tests for the field display, although these are not complete.