### PR TITLE
Feature/48 followup services path

### DIFF
--- a/modules/localgov_services_status/config/optional/pathauto.pattern.localgov_service_status.yml
+++ b/modules/localgov_services_status/config/optional/pathauto.pattern.localgov_service_status.yml
@@ -6,7 +6,7 @@ dependencies:
 id: localgov_service_status
 label: 'Service Status Page'
 type: 'canonical_entities:node'
-pattern: '[node:localgov_services_parent:entity:url:relative]/[node:title]'
+pattern: '[node:localgov_services_parent:entity:url:relative]/status/[node:title]'
 selection_criteria:
   fb899c5a-41f3-4482-9b7d-7f203c4290c4:
     id: node_type

--- a/modules/localgov_services_status/tests/src/Functional/ServiceStatusTest.php
+++ b/modules/localgov_services_status/tests/src/Functional/ServiceStatusTest.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\localgov_services_status\Functional;
 use Drupal\node\NodeInterface;
 use Drupal\Tests\BrowserTestBase;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\Tests\system\Functional\Menu\AssertBreadcrumbTrait;
 
 /**
  * Tests localgov service status pages.
@@ -13,12 +14,15 @@ use Drupal\Tests\node\Traits\NodeCreationTrait;
  */
 class ServiceStatusTest extends BrowserTestBase {
 
+  use AssertBreadcrumbTrait;
   use NodeCreationTrait;
 
   /**
-   * {@inheritdoc}
+   * Test breadcrumbs in the Standard profile.
+   *
+   * @var string
    */
-  protected $defaultTheme = 'stark';
+  protected $profile = 'standard';
 
   /**
    * Modules to enable.
@@ -206,7 +210,7 @@ class ServiceStatusTest extends BrowserTestBase {
       'status' => NodeInterface::PUBLISHED,
     ]);
 
-    $this->createNode([
+    $status = $this->createNode([
       'type' => 'localgov_services_status',
       'title' => 'Test Status',
       'body' => [
@@ -224,6 +228,14 @@ class ServiceStatusTest extends BrowserTestBase {
     $this->drupalGet($alias . '/status');
     $this->assertSession()->statusCodeEquals(200);
     $this->assertSession()->pageTextContains('Test Status');
+
+    $status_alias = \Drupal::service('path_alias.manager')->getAliasByPath('/node/' . $status->id());
+    $this->assertEqual($status_alias, $alias . '/status/test-status');
+    $this->drupalGet($alias . '/status/test-status');
+    $trail = ['' => 'Home'];
+    $trail += [$alias => $landing->getTitle()];
+    $trail += [$alias . '/status' => 'Latest service status'];
+    $this->assertBreadcrumb(NULL, $trail);
   }
 
 }


### PR DESCRIPTION
Small addition to merged localgovdrupal/localgov_services#48

    Services status path should be beneath status page.
    
    Status report nodes if they are to be viewed on a page on their own
    should be under the services status page. They shouldn't be at the
    same level as sublanding pages.