### PR TITLE
#44 inward landing form helper

### DIFF
--- a/modules/localgov_services_navigation/css/children.css
+++ b/modules/localgov_services_navigation/css/children.css
@@ -8,7 +8,7 @@ div.localgov-services-children-list.item-list {
   overflow-y: scroll;
   position: sticky;
   top: 0;
-  z-index: 1000;
+  z-index: 100;
   background-color: #dde;
   padding: 0.5em;
 }

--- a/modules/localgov_services_navigation/css/children.css
+++ b/modules/localgov_services_navigation/css/children.css
@@ -1,0 +1,69 @@
+/**
+ * @file
+ *  Usable CSS for children list on landing page forms.
+ */
+
+div.localgov-services-children-list.item-list {
+  max-height: 20vh;
+  overflow-y: scroll;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background-color: #dde;
+  padding: 0.5em;
+}
+
+
+.localgov-services-children-list.item-list ul,
+.localgov-services-children-list.item-list ul li {
+  list-style-type: none;
+  margin: 0;
+}
+
+.localgov-services-children-list.item-list ul li {
+  display: inline-block;
+	vertical-align: top;
+  width: 48%;
+  margin: 0.1em;
+}
+
+div.localgov-child-drag {
+  min-height: 5em;
+  border: solid 1px black;
+  background-color: #eef;
+	position: relative;
+	top: 0;
+}
+
+div.localgov-child-drag.draggable {
+  cursor: move;
+  padding: 0 0.5em 0.2em 0.5em;
+}
+
+.localgov-child-title {
+  display: block;
+  padding-bottom: 0.2em;
+  font-weight: bold;
+}
+
+.localgov-child-type {
+  display: block;
+  font-weight: lighter;
+  font-size: 0.8em;
+	font-style: italic;
+}
+
+.localgov-child-topics {
+  display: block;
+  font-size: 0.8em;
+}
+
+.localgov-child-info {
+  display: block;
+  font-weight: lighter;
+  font-size: 0.8em;
+  color: #666;
+	text-align: right;
+	padding-top: 1em;
+}
+

--- a/modules/localgov_services_navigation/js/children.js
+++ b/modules/localgov_services_navigation/js/children.js
@@ -1,0 +1,123 @@
+/**
+ * @file
+ *   Drag and Drop addition to Landing forms.
+ *
+ * @see \Drupal\localgov_services_navigation\EntityChildRelationshipUi
+ *
+ * Drag from the listed children that are not referenced by the landing page
+ * yet, to entity reference and link fields, to auto populate them.
+ *
+ * Manually tested with Claro and Stark.
+ *
+ * Uses basic HTML Drag and Drop so will work on most desktop, but not mobile.
+ * For most draggable core uses depreciated jquery_ui draggable and added
+ * SortableJS. SortableJS is for moving in and between lists. This changes
+ * content for different field types, so for more compatibility maybe an
+ * additional library would be required.
+ */
+(function ($, Drupal) {
+
+  var dragChild;
+
+  Drupal.behaviors.localgovServiceChild = {
+    attach: function attach(context, settings) {
+      // Add draggability to child items.
+      var child = $('.localgov-child-drag');
+      child.each(function() {
+        this.setAttribute('draggable', true);
+        this.classList.add('draggable');
+        this.addEventListener('dragstart', function (event) {
+          event.dataTransfer.dropEffect = "move";
+          event.dataTransfer.effectAllowed = "move";
+          dragChild = this;
+        });
+      });
+    }
+  };
+
+  Drupal.behaviors.localgovServiceTaskDrop = {
+    attach: function attach(context, settings) {
+      // Is it always a table. Maybe form-item and then parent?
+      var linkRow = $("[data-drupal-selector='edit-field-common-tasks'] tr");
+      linkRow.each(function() {
+        this.addEventListener('dragover', function (event) {
+          var row = $(event.target).closest('tr');
+          var url = $("input[data-drupal-selector$=uri]", row);
+          if (url.val() == '') {
+            event.preventDefault();
+            event.dataTransfer.dropEffect = "move";
+          }
+        });
+        this.addEventListener('drop', function(event) {
+          var row = $(event.target).closest('tr');
+          var url = $("input[data-drupal-selector$=uri]", row);
+          if (url.val() == '') {
+            event.preventDefault();
+            var title = $("input[data-drupal-selector$=title]", row);
+            title.val(dragChild.getAttribute('data-localgov-title'));
+            url.val(dragChild.getAttribute('data-localgov-url'));
+            $(dragChild).remove();
+          }
+        });
+      });
+    }
+  };
+
+  Drupal.behaviors.localgovServiceChildDrop = {
+    attach: function attach(context, settings) {
+      var linkRow = $("[data-drupal-selector='edit-field-destinations'] tr");
+      linkRow.each(function() {
+        this.addEventListener('dragover', function (event) {
+          var row = $(event.target).closest('tr');
+          var ref = $("input[data-drupal-selector$=target-id]", row);
+          if (ref.val() == '') {
+            event.preventDefault();
+            event.dataTransfer.dropEffect = "move";
+          }
+        });
+        this.addEventListener('drop', function(event) {
+          var row = $(event.target).closest('tr');
+          var ref = $("input[data-drupal-selector$=target-id]", row);
+          if (ref.val() == '') {
+            event.preventDefault();
+            ref.val(dragChild.getAttribute('data-localgov-reference'));
+            $(dragChild).remove();
+          }
+        });
+      });
+    }
+  };
+
+  Drupal.behaviors.localgovServiceSubChildDrop = {
+    attach: function attach(context, settings) {
+      var linkRow = $("[data-drupal-selector$='-subform-topic-list-links'] tr");
+      linkRow.each(function() {
+        this.addEventListener('dragover', function (event) {
+          var row = $(event.target).closest('tr');
+          var url = $("input[data-drupal-selector$=uri]", row);
+          if (url.val() == '') {
+            event.preventDefault();
+            event.dataTransfer.dropEffect = "move";
+          }
+        });
+        this.addEventListener('drop', function(event) {
+          var row = $(event.target).closest('tr');
+          var url = $("input[data-drupal-selector$=uri]", row);
+          if (url.val() == '') {
+            event.preventDefault();
+            var title = $("input[data-drupal-selector$=title]", row);
+            title.val(dragChild.getAttribute('data-localgov-title'));
+            url.val(dragChild.getAttribute('data-localgov-url'));
+            $(dragChild).remove();
+          }
+        });
+      });
+    }
+  };
+
+  // Account for menus for sticky position.
+  $(document).on('drupalViewportOffsetChange', function () {
+    $('div.localgov-services-children-list.item-list').css('top', $('body').css('padding-top'));
+  });
+
+})(jQuery, Drupal);

--- a/modules/localgov_services_navigation/js/children.js
+++ b/modules/localgov_services_navigation/js/children.js
@@ -10,7 +10,7 @@
  * Manually tested with Claro and Stark.
  *
  * Uses basic HTML Drag and Drop so will work on most desktop, but not mobile.
- * For most draggable core uses depreciated jquery_ui draggable and added
+ * For most draggable core uses deprecated jquery_ui draggable and new
  * SortableJS. SortableJS is for moving in and between lists. This changes
  * content for different field types, so for more compatibility maybe an
  * additional library would be required.

--- a/modules/localgov_services_navigation/localgov_services_navigation.libraries.yml
+++ b/modules/localgov_services_navigation/localgov_services_navigation.libraries.yml
@@ -1,0 +1,9 @@
+children:
+  version: 1.x
+  js:
+    js/children.js: {}
+  css:
+    theme:
+      css/children.css: {}
+  dependencies:
+    - core/jquery

--- a/modules/localgov_services_navigation/localgov_services_navigation.module
+++ b/modules/localgov_services_navigation/localgov_services_navigation.module
@@ -77,7 +77,7 @@ function localgov_services_navigation_entity_extra_field_info() {
 /**
  * Implements hook_form_alter().
  */
-function localgov_services_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
+function localgov_services_navigation_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
   return \Drupal::service('class_resolver')
     ->getInstanceFromDefinition(EntityChildRelationshipUi::class)
     ->formAlter($form, $form_state, $form_id);

--- a/modules/localgov_services_navigation/localgov_services_navigation.module
+++ b/modules/localgov_services_navigation/localgov_services_navigation.module
@@ -10,7 +10,6 @@
  *   and in the future make refactoring it easier.
  */
 
-use Drupal\Component\Utility\Html;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\pathauto\Entity\PathautoPattern;

--- a/modules/localgov_services_navigation/localgov_services_navigation.module
+++ b/modules/localgov_services_navigation/localgov_services_navigation.module
@@ -40,8 +40,6 @@ function localgov_services_navigation_theme() {
  * Implements hook_preprocess_HOOK().
  */
 function template_preprocess_localgov_services_navigation_child(&$variables) {
-  $variables['title'] = Html::escape($variables['title']);
-  $variables['type'] = Html::escape($variables['type']);
   $variables['reference'] = $variables['title'] . ' (' . $variables['id'] . ')';
   $variables['topics_list'] = implode(', ', $variables['topics']);
 }

--- a/modules/localgov_services_navigation/localgov_services_navigation.module
+++ b/modules/localgov_services_navigation/localgov_services_navigation.module
@@ -10,9 +10,41 @@
  *   and in the future make refactoring it easier.
  */
 
+use Drupal\Component\Utility\Html;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\pathauto\Entity\PathautoPattern;
+use Drupal\localgov_services_navigation\EntityChildRelationshipUi;
+
+/**
+ * Implements hook_theme().
+ */
+function localgov_services_navigation_theme() {
+  return [
+    'localgov_services_navigation_children' => [
+      'children' => 'render_element',
+    ],
+    'localgov_services_navigation_child' => [
+      'variables' => [
+        'title' => '',
+        'type' => '',
+        'url' => '',
+        'topics' => [],
+        'id' => '',
+      ],
+    ],
+  ];
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function template_preprocess_localgov_services_navigation_child(&$variables) {
+  $variables['title'] = Html::escape($variables['title']);
+  $variables['type'] = Html::escape($variables['type']);
+  $variables['reference'] = $variables['title'] . ' (' . $variables['id'] . ')';
+  $variables['topics_list'] = implode(', ', $variables['topics']);
+}
 
 /**
  * Implements hook_field_wiget_WIDGET_ID_alter().
@@ -34,4 +66,22 @@ function localgov_services_navigation_pathauto_pattern_alter(PathautoPattern $pa
   if ($entity->hasField('localgov_services_parent') && strpos($pattern->getPattern(), '[node:localgov_services_parent:entity:url:relative]') === FALSE) {
     $pattern->setPattern('[node:localgov_services_parent:entity:url:relative]/' . $pattern->getPattern());
   }
+}
+
+/**
+ * Implements hook_entity_extra_field_info().
+ */
+function localgov_services_navigation_entity_extra_field_info() {
+  return \Drupal::service('class_resolver')
+    ->getInstanceFromDefinition(EntityChildRelationshipUi::class)
+    ->entityExtraFieldInfo();
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function localgov_services_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
+  return \Drupal::service('class_resolver')
+    ->getInstanceFromDefinition(EntityChildRelationshipUi::class)
+    ->formAlter($form, $form_state, $form_id);
 }

--- a/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
+++ b/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
@@ -146,6 +146,8 @@ class EntityChildRelationshipUi implements ContainerInjectionInterface {
   protected function childrenField(NodeInterface $node) {
     $children_query = $this->entityTypeManager->getStorage('node')->getQuery();
     $children_query->condition('localgov_services_parent', $node->id());
+    // Exclude status which automatically get addded to page seperately.
+    $children_query->condition('type', 'localgov_services_status', '<>');
     if (!$this->currentUser->hasPermission('bypass node access') && !count($this->moduleHandler->getImplementations('node_grants'))) {
       $children_query->condition('status', NodeInterface::PUBLISHED);
     }

--- a/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
+++ b/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
@@ -148,8 +148,8 @@ class EntityChildRelationshipUi implements ContainerInjectionInterface {
       assert($child instanceof NodeInterface);
       $row = [
         '#node' => $child,
-        '#title' => Html::escape($child->getTitle()),
-        '#type' => Html::escape($child->type->entity->label()),
+        '#title' => $child->getTitle(),
+        '#type' => $child->type->entity->label(),
         '#url' => $child->toUrl()->toString(),
         '#topics' => [],
         '#id' => $child->id(),

--- a/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
+++ b/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
@@ -6,6 +6,7 @@ use Drupal\Component\Utility\Html;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -43,6 +44,13 @@ class EntityChildRelationshipUi implements ContainerInjectionInterface {
   protected $currentUser;
 
   /**
+   * Module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
    * EntityChildRelationshipUi constructor.
    *
    * @param \Drupal\Core\StringTranslation\TranslationInterface $translation
@@ -51,13 +59,16 @@ class EntityChildRelationshipUi implements ContainerInjectionInterface {
    *   Entity type manager.
    * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
    *   Entity repository.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   Module Handler.
    * @param \Drupal\Core\Session\AccountInterface $current_user
    *   The current user.
    */
-  public function __construct(TranslationInterface $translation, EntityTypeManagerInterface $entity_type_manager, EntityRepositoryInterface $entity_repository, AccountInterface $current_user) {
+  public function __construct(TranslationInterface $translation, EntityTypeManagerInterface $entity_type_manager, EntityRepositoryInterface $entity_repository, ModuleHandlerInterface $module_handler, AccountInterface $current_user) {
     $this->stringTranslation = $translation;
     $this->entityTypeManager = $entity_type_manager;
     $this->entityRepository = $entity_repository;
+    $this->moduleHandler = $module_handler;
     $this->currentUser = $current_user;
   }
 
@@ -69,6 +80,7 @@ class EntityChildRelationshipUi implements ContainerInjectionInterface {
       $container->get('string_translation'),
       $container->get('entity_type.manager'),
       $container->get('entity.repository'),
+      $container->get('module_handler'),
       $container->get('current_user')
     );
   }

--- a/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
+++ b/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace Drupal\localgov_services_navigation;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\node\NodeForm;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides helper UI to landing page forms to link to child pages.
+ */
+class EntityChildRelationshipUi implements ContainerInjectionInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The entity repository.
+   *
+   * @var \Drupal\Core\Entity\EntityRepositoryInterface
+   */
+  protected $entityRepository;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $currentUser;
+
+  /**
+   * EntityChildRelationshipUi constructor.
+   *
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $translation
+   *   The string translation service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   Entity type manager.
+   * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
+   *   Entity repository.
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   */
+  public function __construct(TranslationInterface $translation, EntityTypeManagerInterface $entity_type_manager, EntityRepositoryInterface $entity_repository, AccountInterface $current_user) {
+    $this->stringTranslation = $translation;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->entityRepository = $entity_repository;
+    $this->currentUser = $current_user;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('string_translation'),
+      $container->get('entity_type.manager'),
+      $container->get('entity.repository'),
+      $container->get('current_user')
+    );
+  }
+
+  /**
+   * Gets the "extra fields" for a bundle.
+   *
+   * @see hook_entity_extra_field_info()
+   */
+  public function entityExtraFieldInfo() {
+    $fields = [];
+    foreach (['localgov_services_landing', 'localgov_services_sublanding'] as $bundle) {
+      $fields['node'][$bundle]['form']['localgov_services_navigation_children'] = [
+        'label' => $this->t('Unreferenced Children'),
+        'description' => $this->t("Pages that link here that have not yet been placed."),
+        'weight' => -20,
+        'visible' => TRUE,
+      ];
+    }
+
+    return $fields;
+  }
+
+  /**
+   * Alters bundle forms to enforce revision handling.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   * @param string $form_id
+   *   The form id.
+   *
+   * @see hook_form_alter()
+   */
+  public function formAlter(array &$form, FormStateInterface $form_state, $form_id) {
+    $form_object = $form_state->getFormObject();
+    if (
+      $form_object instanceof NodeForm &&
+      ($node = $form_object->getEntity()) &&
+      in_array($node->bundle(), ['localgov_services_landing', 'localgov_services_sublanding']) &&
+      $node->id()
+    ) {
+      $form['localgov_services_navigation_children'] = [
+        '#items' => $this->childrenField($node),
+        '#theme' => 'item_list',
+        '#wrapper_attributes' => ['class' => 'localgov-services-children-list'],
+        '#attached' => ['library' => 'localgov_services_navigation/children'],
+      ];
+    }
+  }
+
+  /**
+   * Return 'extra field' with list of non-linked child nodes.
+   *
+   * @param \Drupal\Node\NodeInterface $node
+   *   The `localgov_service_landing` or `localgov_service_sublanding`.
+   *
+   * @return array
+   *   Array of render arrays listing child nodes referencing, but not yet
+   *   referenced, by the landing page.
+   */
+  protected function childrenField(NodeInterface $node) {
+    $children_query = $this->entityTypeManager->getStorage('node')->getQuery();
+    $children_query->condition('localgov_services_parent', $node->id());
+    if (!$this->currentUser->hasPermission('bypass node access') && !count($this->moduleHandler->getImplementations('node_grants'))) {
+      $children_query->condition('status', NodeInterface::PUBLISHED);
+    }
+    $children = $children_query->execute();
+
+    $unreferenced_children = array_diff($children, self::referencedChildren($node));
+
+    $rows = [];
+    foreach ($unreferenced_children as $nid) {
+      $child = $this->entityTypeManager->getStorage('node')->load($nid);
+      $child = $this->entityRepository->getTranslationFromContext($child);
+      assert($child instanceof NodeInterface);
+      $row = [
+        '#node' => $child,
+        '#title' => Html::escape($child->getTitle()),
+        '#type' => Html::escape($child->type->entity->label()),
+        '#url' => $child->toUrl()->toString(),
+        '#topics' => [],
+        '#id' => $child->id(),
+        '#theme' => 'localgov_services_navigation_child',
+      ];
+      $topics = [];
+      if ($child->hasField('localgov_topic_classified')) {
+        foreach ($child->localgov_topic_classified as $topic) {
+          $topics[] = Html::escape($topic->entity->label());
+        }
+      }
+      $row['#topics'] = $topics;
+      $rows[] = $row;
+    }
+    return $rows;
+  }
+
+  /**
+   * Get IDs of all nodes that a service landing page links to.
+   *
+   * Made public as it's prossibly helpful, although it could live in a
+   * different class?
+   *
+   * @param Drupal\Node\NodeInterface $node
+   *   The `localgov_service_landing` or `localgov_service_sublanding`.
+   */
+  public static function referencedChildren(NodeInterface $node) {
+    $linked = [];
+
+    // Landing: Both child references, and action links.
+    if ($node->bundle() == 'localgov_services_landing') {
+      foreach ($node->field_destinations as $reference) {
+        if (!$reference->isEmpty()) {
+          $linked[] = $reference->getValue()['target_id'];
+        }
+      }
+      foreach ($node->field_common_tasks as $link) {
+        if (
+          !$link->isEmpty() &&
+          ($url = $link->getUrl()) &&
+          $url->isRouted() &&
+          $url->getRouteName() == 'entity.node.canonical'
+        ) {
+          $linked[] = $url->getRouteParameters()['node'];
+        }
+      }
+    }
+    // Sublanding: The links in the paragraphs.
+    if ($node->bundle() == 'localgov_services_sublanding') {
+      foreach ($node->field_topics as $paragraphs) {
+        foreach ($paragraphs->entity->topic_list_links as $link) {
+          if (
+            !$link->isEmpty() &&
+            ($url = $link->getUrl()) &&
+            $url->isRouted() &&
+            $url->getRouteName() == 'entity.node.canonical'
+          ) {
+            $linked[] = $url->getRouteParameters()['node'];
+          }
+        }
+      }
+    }
+    return $linked;
+  }
+
+}

--- a/modules/localgov_services_navigation/templates/localgov-services-navigation-child.html.twig
+++ b/modules/localgov_services_navigation/templates/localgov-services-navigation-child.html.twig
@@ -1,0 +1,25 @@
+{#
+/**
+ * @file
+ * Template for a child 'card' in the unreferenced children list.
+ *
+ * Available variables:
+ *  title - Title of child node.
+ *  type - Bundle label of child node.
+ *  url - Path to child node.
+ *  topics - Array of topic labels.
+ *  topics_list - String of topic labels.
+ *  id - Node ID of child.
+ *  reference - Reference string, title (id).
+ *
+ * @see template_preprocess_localgov_services_navigation_child()
+ */
+#}
+<div class="localgov-child-drag" data-localgov-title="{{title}}" data-localgov-url="{{url}}" data-localgov-reference="{{reference}}" id="localgov-child-drag-{{id}}">
+ <span class="localgov-child-type">{{ type }}</span>
+ <span class="localgov-child-title">{{ title }}</span>
+{% if topics_list|length %}
+ <span class="localgov-child-topics">{{ topics_list }}</span>
+{% endif %}
+ <span class="localgov-child-info">id: {{ id }} path: {{ url }}</span>
+</div>

--- a/modules/localgov_services_navigation/templates/localgov-services-navigation-children.html.twig
+++ b/modules/localgov_services_navigation/templates/localgov-services-navigation-children.html.twig
@@ -1,0 +1,13 @@
+{#
+/**
+ * @file
+ * Template for a list of children 'cards'.
+ *
+ * Available variables:
+ *
+ * @see template_preprocess_localgov_services_navigation_children()
+ */
+#}
+{% for child in children %}
+  {{ child }}
+{% endfor %}

--- a/modules/localgov_services_navigation/tests/src/FunctionalJavascript/LandingPageChildrenTest.php
+++ b/modules/localgov_services_navigation/tests/src/FunctionalJavascript/LandingPageChildrenTest.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Drupal\Tests\localgov_services_navigation\FunctionalJavascript;
+
+use Drupal\Core\Entity\Entity\EntityFormDisplay;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
+use Drupal\node\NodeInterface;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+
+/**
+ * Tests localgov service landing pages unrefernced children list.
+ *
+ * @group localgov_services
+ */
+class LandingPageChildrenTest extends WebDriverTestBase {
+
+  use NodeCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * A user to edit landing pages.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $user;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'localgov_core',
+    'localgov_services',
+    'localgov_services_landing',
+    'localgov_services_sublanding',
+    'localgov_services_navigation',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->createContentType(['type' => 'page']);
+    $field_storage_config = FieldStorageConfig::loadByName('node', 'localgov_services_parent');
+    $field_instance = FieldConfig::create([
+      'field_storage' => $field_storage_config,
+      'bundle' => 'page',
+      'label' => $this->randomMachineName(),
+    ]);
+    $field_instance->save();
+    $this->user = $this->drupalCreateUser([
+      'access content',
+      'create page content',
+      'create localgov_services_landing content',
+      'create localgov_services_sublanding content',
+      'edit own localgov_services_landing content',
+      'edit own localgov_services_sublanding content',
+      'edit own page content',
+    ]);
+    $this->drupalLogin($this->user);
+  }
+
+  /**
+   * Test unreferenced children on landing page.
+   */
+  public function testServiceLandingPageLink() {
+    $landing = $this->createNode([
+      'title' => 'Landing Page 1',
+      'type' => 'localgov_services_landing',
+      'body' => [
+        'summary' => $this->randomString(100),
+        'value' => $this->randomString(100),
+      ],
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+    $landing->save();
+
+    $child[1] = $this->createNode([
+      'title' => 'child "> &one\' <"',
+      'type' => 'page',
+      'localgov_services_parent' => ['target_id' => $landing->id()],
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+    $child[1]->save();
+
+    $child[2] = $this->createNode([
+      'title' => '\'; #child_2\n',
+      'type' => 'page',
+      'localgov_services_parent' => ['target_id' => $landing->id()],
+      'path' => ['alias' => '/foo'],
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+    $child[2]->save();
+
+    $child[3] = $this->createNode([
+      'title' => '( bob )";',
+      'type' => 'page',
+      'localgov_services_parent' => ['target_id' => $landing->id()],
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+    $child[3]->save();
+
+    $this->drupalGet($landing->toUrl('edit-form')->toString());
+    $page = $this->getSession()->getPage();
+    $assert_session = $this->assertSession();
+
+    $assert_session->elementExists('css', '#localgov-child-drag-' . $child[1]->id());
+    // Check attributes. Yes they're returned decoded.
+    $assert_session->elementAttributeContains('css', '#localgov-child-drag-' . $child[1]->id(), 'data-localgov-url', $child[1]->toUrl()->toString());
+    $assert_session->elementAttributeContains('css', '#localgov-child-drag-' . $child[1]->id(), 'data-localgov-title', 'child "> &one\' <"');
+    $assert_session->elementAttributeContains('css', '#localgov-child-drag-' . $child[1]->id(), 'data-localgov-reference', 'child "> &one\' <" (' . $child[1]->id() . ')');
+    // So also check encoding.
+    $element = $page->find('css', '#localgov-child-drag-' . $child[1]->id());
+    $this->assertContains('child &quot;> &amp;one\' <&quot;', $element->getOuterHtml());
+    $element = $page->find('css', '#localgov-child-drag-' . $child[1]->id() . ' .localgov-child-title');
+    $this->assertContains('child "&gt; &amp;one\' &lt;"', $element->getHtml());
+
+    // Drag the child to a Tasks Link field.
+    $this->clickLink('Common tasks');
+    $drag = $page->find('css', '#localgov-child-drag-' . $child[1]->id());
+    $target = $page->find('css', '#edit-field-common-tasks-0-uri');
+    $drag->dragTo($target);
+    // Check it got populated.
+    $assert_session->fieldValueEquals('edit-field-common-tasks-0-uri', $child[1]->toUrl()->toString());
+    $assert_session->fieldValueEquals('edit-field-common-tasks-0-title', 'child "> &one\' <"');
+
+    // Drag the child to a Tasks Link field.
+    $drag = $page->find('css', '#localgov-child-drag-' . $child[2]->id());
+    $target = $page->find('css', '#edit-field-common-tasks-1-uri');
+    $drag->dragTo($target);
+    // Check it got populated.
+    $assert_session->fieldValueEquals('edit-field-common-tasks-1-uri', '/foo');
+    $assert_session->fieldValueEquals('edit-field-common-tasks-1-title', '\'; #child_2\n');
+
+    // Drag the child to a populated Tasks Link field.
+    $drag = $page->find('css', '#localgov-child-drag-' . $child[3]->id());
+    $target = $page->find('css', '#edit-field-common-tasks-1-uri');
+    $drag->dragTo($target);
+    // Shouldn't overwrite.
+    $assert_session->fieldValueEquals('edit-field-common-tasks-1-uri', '/foo');
+    $assert_session->fieldValueEquals('edit-field-common-tasks-1-title', '\'; #child_2\n');
+
+  }
+
+  /**
+   * Test unreferenced children on landing page.
+   */
+  public function testServiceLandingPageReference() {
+    $landing = $this->createNode([
+      'title' => 'Landing Page 1',
+      'type' => 'localgov_services_landing',
+      'body' => [
+        'summary' => $this->randomString(100),
+        'value' => $this->randomString(100),
+      ],
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+    $landing->save();
+
+    $child[3] = $this->createNode([
+      'title' => '( bob )";',
+      'type' => 'page',
+      'localgov_services_parent' => ['target_id' => $landing->id()],
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+    $child[3]->save();
+
+    $child[4] = $this->createNode([
+      'title' => 'and last one left',
+      'type' => 'page',
+      'localgov_services_parent' => ['target_id' => $landing->id()],
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+    $child[4]->save();
+
+    $this->drupalGet($landing->toUrl('edit-form')->toString());
+    $page = $this->getSession()->getPage();
+    $assert_session = $this->assertSession();
+
+    // Drag the child to a Tasks Link field.
+    $this->clickLink('Child pages');
+    $drag = $page->find('css', '#localgov-child-drag-' . $child[3]->id());
+    $target = $page->find('css', '#edit-field-destinations-0-target-id');
+    $drag->dragTo($target);
+    // Check it got populated.
+    $assert_session->fieldValueEquals('edit-field-destinations-0-target-id', '( bob )"; (' . $child[3]->id() . ')');
+  }
+
+}

--- a/modules/localgov_services_navigation/tests/src/FunctionalJavascript/LandingPageChildrenTest.php
+++ b/modules/localgov_services_navigation/tests/src/FunctionalJavascript/LandingPageChildrenTest.php
@@ -2,12 +2,10 @@
 
 namespace Drupal\Tests\localgov_services_navigation\FunctionalJavascript;
 
-use Drupal\Core\Entity\Entity\EntityFormDisplay;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
 use Drupal\node\NodeInterface;
-use Drupal\taxonomy\Entity\Term;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 
 /**

--- a/modules/localgov_services_navigation/tests/src/FunctionalJavascript/LandingPageChildrenTest.php
+++ b/modules/localgov_services_navigation/tests/src/FunctionalJavascript/LandingPageChildrenTest.php
@@ -165,6 +165,22 @@ class LandingPageChildrenTest extends WebDriverTestBase {
     ]);
     $landing->save();
 
+    $this->createContentType(['type' => 'localgov_services_status']);
+    $field_storage_config = FieldStorageConfig::loadByName('node', 'localgov_services_parent');
+    $field_instance = FieldConfig::create([
+      'field_storage' => $field_storage_config,
+      'bundle' => 'localgov_services_status',
+      'label' => $this->randomMachineName(),
+    ]);
+    $field_instance->save();
+    $status = $this->createNode([
+      'title' => 'status update listed on page elsewhere automatically',
+      'type' => 'localgov_services_status',
+      'localgov_services_parent' => ['target_id' => $landing->id()],
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+    $status->save();
+
     $child[3] = $this->createNode([
       'title' => '( bob )";',
       'type' => 'page',
@@ -172,7 +188,6 @@ class LandingPageChildrenTest extends WebDriverTestBase {
       'status' => NodeInterface::PUBLISHED,
     ]);
     $child[3]->save();
-
     $child[4] = $this->createNode([
       'title' => 'and last one left',
       'type' => 'page',
@@ -184,6 +199,9 @@ class LandingPageChildrenTest extends WebDriverTestBase {
     $this->drupalGet($landing->toUrl('edit-form')->toString());
     $page = $this->getSession()->getPage();
     $assert_session = $this->assertSession();
+
+    // Check status page in the list of unreferenced children.
+    $assert_session->pageTextNotContains('status update listed on page elsewhere automatically');
 
     // Drag the child to a Tasks Link field.
     $this->clickLink('Child pages');

--- a/modules/localgov_services_navigation/tests/src/Kernel/ChildReferencesTest.php
+++ b/modules/localgov_services_navigation/tests/src/Kernel/ChildReferencesTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Drupal\Tests\localgov_services_navigation\Kernel;
+
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\Tests\pathauto\Functional\PathautoTestHelperTrait;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\localgov_services_navigation\EntityChildRelationshipUi;
+use Drupal\node\Entity\Node;
+use Drupal\node\NodeInterface;
+use Drupal\paragraphs\Entity\Paragraph;
+use Drupal\Tests\field\Traits\EntityReferenceTestTrait;
+use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\user\Entity\User;
+
+/**
+ * Kernel test check Services Pathauto.
+ *
+ * @group localgov_services_navigation
+ */
+class ChildReferencesTest extends KernelTestBase {
+
+  use ContentTypeCreationTrait;
+  use EntityReferenceTestTrait;
+  use NodeCreationTrait;
+  use PathautoTestHelperTrait;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'system',
+    'field',
+    'field_group',
+    'text',
+    'link',
+    'user',
+    'node',
+    'path',
+    'file',
+    'entity_reference_revisions',
+    'path_alias',
+    'paragraphs',
+    'pathauto',
+    'taxonomy',
+    'token',
+    'views',
+    'filter',
+    //    'language',
+    'localgov_core',
+    'localgov_services',
+    'localgov_services_navigation',
+    'localgov_services_landing',
+    'localgov_services_sublanding',
+  ];
+
+  /**
+   * Service Landing page.
+   *
+   * @var \Drupal\node\NodeInterface
+   */
+  protected $serviceLanding;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setup();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('paragraph');
+    $this->installEntitySchema('taxonomy_term');
+    $this->installEntitySchema('path_alias');
+    $this->installSchema('node', ['node_access']);
+    $this->installConfig([
+      'filter',
+      'pathauto',
+      'node',
+      'system',
+      'localgov_core',
+      'localgov_services',
+      'localgov_services_navigation',
+      'localgov_services_landing',
+      'localgov_services_sublanding',
+    ]);
+
+    // Create a content type to put into services.
+    $this->createContentType(['type' => 'page']);
+  }
+
+  /**
+   * Test all referenced children returned.
+   */
+  public function testReferencedChildren() {
+    // Workaround https://www.drupal.org/project/drupal/issues/3056234
+    User::create([
+      'name' => '',
+      'uid' => 0,
+    ])->save();
+
+    // Create a service.
+    $service_landing = $this->createNode([
+      'title' => 'Landing Page 1',
+      'type' => 'localgov_services_landing',
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+
+    $this->assertEmpty(EntityChildRelationshipUi::referencedChildren($service_landing));
+
+    // Node in the entity reference fields.
+    $node = $this->createNode([
+      'title' => 'Page 1',
+      'type' => 'page',
+    ]);
+    $node->save();
+    $node = Node::load($node->id());
+    $service_landing->field_destinations->appendItem(['target_id' => $node->id()]);
+    $this->assertEqual(EntityChildRelationshipUi::referencedChildren($service_landing), [$node->id()]);
+
+    // Node in the action link fields.
+    $node = $this->createNode([
+      'title' => 'Page 2',
+      'type' => 'page',
+    ]);
+    $node->save();
+    $node = Node::load($node->id());
+    $service_landing->field_common_tasks->appendItem(['uri' => 'internal:' . $node->toUrl()->toString()]);
+    $ids = EntityChildRelationshipUi::referencedChildren($service_landing);
+    $this->assertCount(2, $ids);
+    $this->assertTrue(in_array($node->id(), $ids));
+
+    // Node in the action link fields that was entered with the path alias.
+    // I can get it to report this in the UI including $link->getValue() being
+    // internal:/foo, but ->getUrl returning the routed value but I can't
+    // reproduce it in this test.
+    // @codingStandardsIgnoreStart
+    // $node = $this->createNode([
+    //   'title' => 'Page 3',
+    //   'type' => 'page',
+    //   'path' => ['alias' => '/foo'],
+    // ]);
+    // $node->save();
+    // $node = Node::load($node->id());
+    // $this->assertEntityAlias($node, '/foo');
+    // $this->assertAliasExists(['path' => '/node/' . $node->id(), 'alias' => '/foo']);
+    // $service_landing->field_common_tasks->appendItem(['uri' => 'internal:/foo']);
+    // $service_landing->save();
+    // $service_landing = Node::load($service_landing->id());
+    // $ids = EntityChildRelationshipUi::referencedChildren($service_landing);
+    // $this->assertCount(3, $ids);
+    // $this->assertTrue(in_array($node->id(), $ids));
+    // @codingStandardsIgnoreEnd
+
+    $service_sublanding = $this->createNode([
+      'title' => 'Sublanding Page 1',
+      'type' => 'localgov_services_sublanding',
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+    $this->assertEmpty(EntityChildRelationshipUi::referencedChildren($service_sublanding));
+    // Node in the entity reference fields.
+    $service_path = '/' . $this->randomMachineName(8);
+    $node = $this->createNode([
+      'title' => 'Page 1',
+      'type' => 'page',
+      'path' => ['alias' => $service_path],
+    ]);
+    $header = $this->randomMachineName(12);
+    $tlb_header = Paragraph::create([
+      'type' => 'topic_list_builder',
+      'topic_list_header' => ['value' => $header],
+      'topic_list_links' => [
+        'uri' => 'internal:' . $node->toUrl()->toString(),
+        'title' => 'Example internal link',
+      ],
+    ]);
+    $tlb_header->save();
+    $service_sublanding->field_topics->appendItem($tlb_header);
+    $service_sublanding->save();
+
+    $ids = EntityChildRelationshipUi::referencedChildren($service_sublanding);
+    $this->assertCount(1, $ids);
+    $this->assertTrue(in_array($node->id(), $ids));
+  }
+
+}

--- a/modules/localgov_services_navigation/tests/src/Kernel/ChildReferencesTest.php
+++ b/modules/localgov_services_navigation/tests/src/Kernel/ChildReferencesTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\localgov_services_navigation\Kernel;
 
-use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\Tests\pathauto\Functional\PathautoTestHelperTrait;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\localgov_services_navigation\EntityChildRelationshipUi;
@@ -49,7 +48,6 @@ class ChildReferencesTest extends KernelTestBase {
     'token',
     'views',
     'filter',
-    //    'language',
     'localgov_core',
     'localgov_services',
     'localgov_services_navigation',


### PR DESCRIPTION
Working, to be integrated further solution to #44.

Lists 'child' pages referencing (sub-)landing pages that have not yet been referenced by the relevant link/entity reference fields. Additional option to drag-and-drop on desktop to those fields to populate them.

Will require further styling to integrate it, current css works however for claro or stark. Expecting further changes, tests for PHP, and some but not all javascript - further submission of form after drag for example?