### PR TITLE
Bug fix: Do not list unpublished child pages in Service sub pages.

### DIFF
--- a/modules/localgov_services_sublanding/css/child-pages.css
+++ b/modules/localgov_services_sublanding/css/child-pages.css
@@ -1,0 +1,18 @@
+/**
+ * @file
+ * Extra style rules for the child pages.
+ */
+
+.localgov-services-sublanding-child-entity--unpublished {
+  background-color: #FFCC33;
+}
+.localgov-services-sublanding-child-entity--unpublished::after {
+  content: 'Unpublished';
+  display: inline-block;
+  margin: .25em;
+  padding-left: .25em;
+  padding-right: .25em;
+  color: white;
+  background-color: black;
+  font-weight: bold;
+}

--- a/modules/localgov_services_sublanding/localgov_services_sublanding.libraries.yml
+++ b/modules/localgov_services_sublanding/localgov_services_sublanding.libraries.yml
@@ -1,0 +1,5 @@
+# Extra style rules for the Child page links of the Sub hub page.
+child_pages:
+  css:
+    theme:
+      css/child-pages.css: {}

--- a/modules/localgov_services_sublanding/src/Plugin/Field/FieldFormatter/LinkNodeReference.php
+++ b/modules/localgov_services_sublanding/src/Plugin/Field/FieldFormatter/LinkNodeReference.php
@@ -12,7 +12,6 @@ use Drupal\Core\Field\FormatterBase;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Url;
 use Drupal\link\Plugin\Field\FieldType\LinkItem;
-use http\Exception\UnexpectedValueException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -142,7 +141,7 @@ class LinkNodeReference extends FormatterBase implements ContainerFactoryPluginI
       }
     }
     // Fallback to buildExternal() if the internal route is not valid.
-    catch (UnexpectedValueException $exception) {
+    catch (\UnexpectedValueException $exception) {
       return $this->buildExternal($item);
     }
   }

--- a/modules/localgov_services_sublanding/tests/src/Functional/UnpublishedLinkNodeReference.php
+++ b/modules/localgov_services_sublanding/tests/src/Functional/UnpublishedLinkNodeReference.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\tests\localgov_services_sublanding\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+use Drupal\node\NodeInterface;
+use Drupal\node\Entity\Node;
+use Drupal\Component\Utility\Random;
+
+/**
+ * Functional tests for the LinkNodeReference field formatter.
+ *
+ * Tests that:
+ * - Unpublished child nodes are not listed by the parent page to anonymous
+ *   users.
+ * - When an unpublished node is added as a child page and later published, it
+ *   should be listed by the parent page for anonymous users.
+ * - Unpublished child nodes are clearly highlighted to editors.
+ *
+ * @group localgov_services_sublanding
+ */
+class UnpublishedLinkNodeReference extends BrowserTestBase {
+
+  /**
+   * Setup Service sub page and an editor user capable of editing it.
+   *
+   * Create an unpublished Service page and set it as a child page of a new
+   * Service sub page.  The LinkNodeReference field formatter of the parent page
+   * lists this child page as a teaser.
+   */
+  public function setUp() {
+
+    parent::setUp();
+
+    $this->editorUser = $this->drupalCreateUser([
+      'administer content types',
+      'administer nodes',
+      'bypass node access',
+    ]);
+    $this->drupalLogin($this->editorUser);
+
+    $service_sub_page = $this->drupalCreateNode([
+      'type' => 'localgov_services_sublanding',
+      'title' => self::SERVICE_SUB_PAGE_TITLE,
+      'status' => NodeInterface::PUBLISHED,
+      'body' => [
+        [
+          'summary' => 'No summary',
+          'value' => (new Random)->paragraphs(3),
+          'format' => filter_default_format(),
+        ],
+      ],
+    ]);
+    $this->serviceSubPageLastNid = $service_sub_page->id();
+
+    // Create a Service page which will be used as the child page.
+    $child_page = $this->drupalCreateNode([
+      'title'  => self::CHILD_PAGE_TITLE,
+      'status' => NodeInterface::NOT_PUBLISHED,
+      'type'   => 'localgov_services_page',
+      'localgov_services_parent' => [
+        [
+          'target_id' => $this->serviceSubPageLastNid,
+        ],
+      ],
+    ]);
+    $this->childPageLastNid = $child_page->id();
+
+    // Add child page to Service sub page.
+    $this->drupalGet("node/{$this->serviceSubPageLastNid}/edit");
+    $this->submitForm([], 'Add Topic list builder');
+
+    $this->getSession()->getPage()->fillField('field_topics[0][subform][topic_list_links][0][uri]', self::CHILD_PAGE_TITLE . " ($this->childPageLastNid)");
+    $this->submitForm([], 'Save');
+    $this->assertSession()->pageTextNotContains(self::FORM_ERROR_MSG);
+
+    $this->drupalLogout();
+
+    // Create a cached copy of the Service sub page.
+    $this->drupalGet("node/{$this->serviceSubPageLastNid}");
+  }
+
+  /**
+   * Service sub pages should not list **unpublished** child pages.
+   */
+  public function testDoNotListUnpublishedChildPages() {
+
+    $this->drupalGet("node/{$this->serviceSubPageLastNid}");
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains(self::SERVICE_SUB_PAGE_TITLE);
+    $this->assertSession()->pageTextNotContains(self::CHILD_PAGE_TITLE);
+  }
+
+  /**
+   * Service sub pages should list **published** child pages.
+   *
+   * This has to be true even when the child page was added when it was still
+   * unpublished.
+   */
+  public function testDoListPublishedChildPages() {
+
+    // Publish the child page.
+    $this->drupalLogin($this->editorUser);
+    $child_node = Node::load($this->childPageLastNid);
+    $child_node->status = NodeInterface::PUBLISHED;
+    $child_node->save();
+    $this->drupalLogout();
+
+    // Now view the Service sub page as an anonymous user.  It should list the
+    // child page.
+    $this->drupalGet("node/{$this->serviceSubPageLastNid}");
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains(self::SERVICE_SUB_PAGE_TITLE);
+    $this->assertSession()->pageTextContains(self::CHILD_PAGE_TITLE);
+    $this->assertSession()->ResponseNotContains('localgov-services-sublanding-child-entity--unpublished');
+  }
+
+  /**
+   * Unpublished child pages should be clearly highlighted to editors.
+   *
+   * The presence of the localgov-services-sublanding-child-entity--unpublished
+   * DOM class is indicative of this highlighting.
+   */
+  public function testHighlightUnpublishedChildPages() {
+
+    $this->drupalLogin($this->editorUser);
+
+    $this->drupalGet("node/{$this->serviceSubPageLastNid}");
+    $this->assertSession()->statusCodeEquals(200);
+
+    $this->assertSession()->pageTextContains(self::CHILD_PAGE_TITLE);
+    $this->assertSession()->ResponseContains('localgov-services-sublanding-child-entity--unpublished');
+  }
+
+  /**
+   * Node id of the last generated Service sub page.
+   *
+   * @var int
+   */
+  protected $serviceSubPageLastNid = -1;
+
+  /**
+   * Node id of the last generated child page.
+   *
+   * @var int
+   */
+  protected $childPageLastNid = -1;
+
+  /**
+   * Content editor user.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $editorUser;
+
+  /**
+   * As they say on their tins.
+   */
+  const SERVICE_SUB_PAGE_TITLE = 'Service sub page title';
+  const CHILD_PAGE_TITLE = 'Child page title';
+  const FORM_ERROR_MSG = 'Error message';
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  protected static $modules = ['localgov_services_sublanding'];
+
+  /**
+   * Theme to use during the functional tests.
+   *
+   * @var string
+   */
+  protected $defaultTheme = 'stark';
+
+}


### PR DESCRIPTION
When unpublished pages are added as Child pages to Service sub pages, they should not be listed when that Service Sub page is viewed.  Those able to view unpublished pages (e.g. editors) will see these child pages listed in the parent Service sub page, but such child pages will be clearly highlighted.