### PR TITLE
Add block display to services view

### DIFF
--- a/modules/localgov_services_landing/config/install/views.view.services.yml
+++ b/modules/localgov_services_landing/config/install/views.view.services.yml
@@ -193,6 +193,21 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
+  block_service_list:
+    display_plugin: block
+    id: block_service_list
+    display_title: Block
+    position: 1
+    display_options:
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
   page_1:
     display_plugin: page
     id: page_1


### PR DESCRIPTION
This PR adds a block display to the services list view, and is used in the LocalGov Drupal install profile for a home page block. (See [/localgovdrupal/localgov/issues/96](/localgovdrupal/localgov/issues/96))