### PR TITLE
Initial functionality for addition paragraph field for Promoted Content on Service Landing Page.

### DIFF
--- a/modules/localgov_services_landing/config/install/core.entity_form_display.node.localgov_services_landing.default.yml
+++ b/modules/localgov_services_landing/config/install/core.entity_form_display.node.localgov_services_landing.default.yml
@@ -17,11 +17,12 @@ dependencies:
     - field.field.node.localgov_services_landing.field_phone
     - field.field.node.localgov_services_landing.field_popular_topics
     - field.field.node.localgov_services_landing.field_twitter
+    - field.field.node.localgov_services_landing.localgov_service_promoted
     - node.type.localgov_services_landing
   module:
-    - content_moderation
     - field_group
     - link
+    - paragraphs
     - path
     - text
 third_party_settings:
@@ -74,6 +75,7 @@ third_party_settings:
         - group_description
         - group_common_tasks
         - group_destinations
+        - group_promoted_content
         - group_social_media
         - group_popular_topics
         - group_contact
@@ -151,6 +153,21 @@ third_party_settings:
         required_fields: false
       label: Location
       region: content
+    group_promoted_content:
+      children:
+        - localgov_service_promoted
+      parent_name: group_tabs
+      weight: 4
+      format_type: tab
+      region: content
+      format_settings:
+        id: ''
+        classes: ''
+        direction: vertical
+        formatter: closed
+        description: ''
+        required_fields: true
+      label: 'Promoted content'
 id: node.localgov_services_landing.default
 targetEntityType: node
 bundle: localgov_services_landing
@@ -163,6 +180,7 @@ content:
       rows: 9
       summary_rows: 3
       placeholder: ''
+      show_summary: false
     third_party_settings: {  }
     region: content
   created:
@@ -287,6 +305,23 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
+  localgov_service_promoted:
+    type: entity_reference_paragraphs
+    weight: 101
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+    third_party_settings: {  }
+    region: content
+  localgov_services_navigation_children:
+    weight: -20
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
     weight: 100

--- a/modules/localgov_services_landing/config/install/core.entity_form_display.paragraph.localgov_service_promoted.default.yml
+++ b/modules/localgov_services_landing/config/install/core.entity_form_display.paragraph.localgov_service_promoted.default.yml
@@ -1,0 +1,35 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.localgov_service_promoted.localgov_image
+    - field.field.paragraph.localgov_service_promoted.localgov_service_url
+    - paragraphs.paragraphs_type.localgov_service_promoted
+  module:
+    - link
+id: paragraph.localgov_service_promoted.default
+targetEntityType: paragraph
+bundle: localgov_service_promoted
+mode: default
+content:
+  localgov_image:
+    weight: 0
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  localgov_service_url:
+    weight: 1
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+hidden:
+  created: true
+  status: true

--- a/modules/localgov_services_landing/config/install/core.entity_view_display.node.localgov_services_landing.default.yml
+++ b/modules/localgov_services_landing/config/install/core.entity_view_display.node.localgov_services_landing.default.yml
@@ -17,8 +17,10 @@ dependencies:
     - field.field.node.localgov_services_landing.field_phone
     - field.field.node.localgov_services_landing.field_popular_topics
     - field.field.node.localgov_services_landing.field_twitter
+    - field.field.node.localgov_services_landing.localgov_service_promoted
     - node.type.localgov_services_landing
   module:
+    - entity_reference_revisions
     - link
     - localgov_services_landing
     - text
@@ -126,6 +128,15 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
+  localgov_service_promoted:
+    type: entity_reference_revisions_entity_view
+    weight: 12
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
 hidden:
   content_moderation_control: true
   field_common_tasks: true

--- a/modules/localgov_services_landing/config/install/core.entity_view_display.node.localgov_services_landing.search_result.yml
+++ b/modules/localgov_services_landing/config/install/core.entity_view_display.node.localgov_services_landing.search_result.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.node.localgov_services_landing.field_phone
     - field.field.node.localgov_services_landing.field_popular_topics
     - field.field.node.localgov_services_landing.field_twitter
+    - field.field.node.localgov_services_landing.localgov_service_promoted
     - node.type.localgov_services_landing
   module:
     - text
@@ -48,3 +49,4 @@ hidden:
   field_popular_topics: true
   field_twitter: true
   links: true
+  localgov_service_promoted: true

--- a/modules/localgov_services_landing/config/install/core.entity_view_display.node.localgov_services_landing.teaser.yml
+++ b/modules/localgov_services_landing/config/install/core.entity_view_display.node.localgov_services_landing.teaser.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.node.localgov_services_landing.field_phone
     - field.field.node.localgov_services_landing.field_popular_topics
     - field.field.node.localgov_services_landing.field_twitter
+    - field.field.node.localgov_services_landing.localgov_service_promoted
     - node.type.localgov_services_landing
   module:
     - text
@@ -48,3 +49,4 @@ hidden:
   field_popular_topics: true
   field_twitter: true
   links: true
+  localgov_service_promoted: true

--- a/modules/localgov_services_landing/config/install/core.entity_view_display.paragraph.localgov_service_promoted.default.yml
+++ b/modules/localgov_services_landing/config/install/core.entity_view_display.paragraph.localgov_service_promoted.default.yml
@@ -4,7 +4,7 @@ dependencies:
   config:
     - field.field.paragraph.localgov_service_promoted.localgov_image
     - field.field.paragraph.localgov_service_promoted.localgov_service_url
-    - image.style.manual_3_2_crop
+    - image.style.medium
     - paragraphs.paragraphs_type.localgov_service_promoted
   module:
     - link
@@ -18,7 +18,7 @@ content:
     weight: 0
     label: hidden
     settings:
-      image_style: manual_3_2_crop
+      image_style: medium
       image_link: ''
     third_party_settings: {  }
     type: media_thumbnail

--- a/modules/localgov_services_landing/config/install/core.entity_view_display.paragraph.localgov_service_promoted.default.yml
+++ b/modules/localgov_services_landing/config/install/core.entity_view_display.paragraph.localgov_service_promoted.default.yml
@@ -1,0 +1,38 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.localgov_service_promoted.localgov_image
+    - field.field.paragraph.localgov_service_promoted.localgov_service_url
+    - image.style.manual_3_2_crop
+    - paragraphs.paragraphs_type.localgov_service_promoted
+  module:
+    - link
+    - media
+id: paragraph.localgov_service_promoted.default
+targetEntityType: paragraph
+bundle: localgov_service_promoted
+mode: default
+content:
+  localgov_image:
+    weight: 0
+    label: hidden
+    settings:
+      image_style: manual_3_2_crop
+      image_link: ''
+    third_party_settings: {  }
+    type: media_thumbnail
+    region: content
+  localgov_service_url:
+    weight: 1
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+hidden: {  }

--- a/modules/localgov_services_landing/config/install/field.field.node.localgov_services_landing.localgov_service_promoted.yml
+++ b/modules/localgov_services_landing/config/install/field.field.node.localgov_services_landing.localgov_service_promoted.yml
@@ -1,0 +1,48 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_service_promoted
+    - node.type.localgov_services_landing
+    - paragraphs.paragraphs_type.localgov_service_promoted
+  module:
+    - entity_reference_revisions
+id: node.localgov_services_landing.localgov_service_promoted
+field_name: localgov_service_promoted
+entity_type: node
+bundle: localgov_services_landing
+label: 'Promoted content'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      localgov_service_promoted: localgov_service_promoted
+    target_bundles_drag_drop:
+      from_library:
+        weight: 8
+        enabled: false
+      localgov_contact:
+        weight: 9
+        enabled: false
+      localgov_image:
+        weight: 10
+        enabled: false
+      localgov_link:
+        weight: 11
+        enabled: false
+      localgov_service_promoted:
+        enabled: true
+        weight: 12
+      localgov_text:
+        weight: 13
+        enabled: false
+      topic_list_builder:
+        weight: 14
+        enabled: false
+field_type: entity_reference_revisions

--- a/modules/localgov_services_landing/config/install/field.field.paragraph.localgov_service_promoted.localgov_image.yml
+++ b/modules/localgov_services_landing/config/install/field.field.paragraph.localgov_service_promoted.localgov_image.yml
@@ -3,7 +3,6 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.localgov_image
-    - media.type.image
     - paragraphs.paragraphs_type.localgov_service_promoted
 id: paragraph.localgov_service_promoted.localgov_image
 field_name: localgov_image

--- a/modules/localgov_services_landing/config/install/field.field.paragraph.localgov_service_promoted.localgov_image.yml
+++ b/modules/localgov_services_landing/config/install/field.field.paragraph.localgov_service_promoted.localgov_image.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.localgov_image
+    - media.type.image
+    - paragraphs.paragraphs_type.localgov_service_promoted
+id: paragraph.localgov_service_promoted.localgov_image
+field_name: localgov_image
+entity_type: paragraph
+bundle: localgov_service_promoted
+label: Image
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/localgov_services_landing/config/install/field.field.paragraph.localgov_service_promoted.localgov_service_url.yml
+++ b/modules/localgov_services_landing/config/install/field.field.paragraph.localgov_service_promoted.localgov_service_url.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.localgov_service_url
+    - paragraphs.paragraphs_type.localgov_service_promoted
+  module:
+    - link
+id: paragraph.localgov_service_promoted.localgov_service_url
+field_name: localgov_service_url
+entity_type: paragraph
+bundle: localgov_service_promoted
+label: Link
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 2
+field_type: link

--- a/modules/localgov_services_landing/config/install/field.storage.node.localgov_service_promoted.yml
+++ b/modules/localgov_services_landing/config/install/field.storage.node.localgov_service_promoted.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - node
+    - paragraphs
+id: node.localgov_service_promoted
+field_name: localgov_service_promoted
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: 3
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/localgov_services_landing/config/install/field.storage.paragraph.localgov_service_url.yml
+++ b/modules/localgov_services_landing/config/install/field.storage.paragraph.localgov_service_url.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.localgov_service_url
+field_name: localgov_service_url
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/localgov_services_landing/config/install/paragraphs.paragraphs_type.localgov_service_promoted.yml
+++ b/modules/localgov_services_landing/config/install/paragraphs.paragraphs_type.localgov_service_promoted.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies: {  }
+id: localgov_service_promoted
+label: 'Service: Promoted content'
+icon_uuid: null
+icon_default: null
+description: 'Promoted content for services landing page, with image and link.'
+behavior_plugins: {  }

--- a/modules/localgov_services_landing/localgov_services_landing.info.yml
+++ b/modules/localgov_services_landing/localgov_services_landing.info.yml
@@ -9,9 +9,11 @@ dependencies:
   - drupal:link
   - drupal:menu_ui
   - drupal:node
+  - drupal:paragraphs
   - drupal:text
   - drupal:user
   - drupal:views
   - localgov_services:localgov_services
   - localgov_services:localgov_services_sublanding
   - localgov_services:localgov_services_page
+  - localgov_core:localgov_media

--- a/modules/localgov_services_landing/localgov_services_landing.module
+++ b/modules/localgov_services_landing/localgov_services_landing.module
@@ -14,6 +14,10 @@ function localgov_services_landing_theme($existing, $type, $theme, $path) {
       'template' => 'node--localgov-services-landing--full',
       'base hook' => 'node',
     ],
+    'paragraph__localgov_service_promoted__default' => [
+      'template' => 'paragraph--localgov-service-promoted--default',
+      'base hook' => 'paragraph',
+    ],
     'taxonomy_vertical_list' => [
       'template' => 'taxonomy-vertical-list',
       'variables' => [

--- a/modules/localgov_services_landing/templates/node--localgov-services-landing--full.html.twig
+++ b/modules/localgov_services_landing/templates/node--localgov-services-landing--full.html.twig
@@ -23,6 +23,12 @@
 </section>
 {% endif %}
 
+{% if content.localgov_service_promoted %}
+<section class="localgov-service-promoted">
+  {{ content.localgov_service_promoted }}
+</section>
+{% endif %}
+
 {% if service_updates %}
 {{ service_updates }}
 {% endif %}

--- a/modules/localgov_services_landing/templates/paragraph--localgov-service-promoted--default.html.twig
+++ b/modules/localgov_services_landing/templates/paragraph--localgov-service-promoted--default.html.twig
@@ -1,0 +1,30 @@
+{#
+/**
+ * @file
+ * Services Promoted Content paragraph.
+ *
+ * Wraps the content of the paragraph in the link to the content.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished'
+  ]
+%}
+{% block paragraph %}
+  <article{{ attributes.addClass(classes) }}>
+    <a href="{{ content.localgov_service_url.0['#url'] }}">
+    {% block content %}
+      {{ content|without('localgov_service_url') }}
+      <h3 class="pl-2">{{ content.localgov_service_url.0['#title'] }}</h3>
+    {% endblock %}
+    </a>
+  </article>
+{% endblock paragraph %}

--- a/modules/localgov_services_navigation/js/children.js
+++ b/modules/localgov_services_navigation/js/children.js
@@ -35,6 +35,7 @@
     }
   };
 
+  // field_common_tasks link fields.
   Drupal.behaviors.localgovServiceTaskDrop = {
     attach: function attach(context, settings) {
       // Is it always a table. Maybe form-item and then parent?
@@ -63,6 +64,35 @@
     }
   };
 
+  // Paragraphs with a localgov_service_url link field.
+  Drupal.behaviors.localgovServiceTaskParaDrop = {
+    attach: function attach(context, settings) {
+      var linkRow = $("[data-drupal-selector*='localgov-service-url'] fieldset");
+      linkRow.each(function() {
+        this.addEventListener('dragover', function (event) {
+          var row = $(event.target).closest('fieldset');
+          var url = $("input[data-drupal-selector$=uri]", row);
+          if (url.val() == '') {
+            event.preventDefault();
+            event.dataTransfer.dropEffect = "move";
+          }
+        });
+        this.addEventListener('drop', function(event) {
+          var row = $(event.target).closest('fieldset');
+          var url = $("input[data-drupal-selector$=uri]", row);
+          if (url.val() == '') {
+            event.preventDefault();
+            var title = $("input[data-drupal-selector$=title]", row);
+            title.val(dragChild.getAttribute('data-localgov-title'));
+            url.val(dragChild.getAttribute('data-localgov-url'));
+            $(dragChild).remove();
+          }
+        });
+      });
+    }
+  };
+
+  // Child field_destinations entity reference fields.
   Drupal.behaviors.localgovServiceChildDrop = {
     attach: function attach(context, settings) {
       var linkRow = $("[data-drupal-selector='edit-field-destinations'] tr");

--- a/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
+++ b/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
@@ -211,6 +211,20 @@ class EntityChildRelationshipUi implements ContainerInjectionInterface {
           $linked[] = $url->getRouteParameters()['node'];
         }
       }
+      foreach ($node->localgov_service_promoted as $reference) {
+        if (!$reference->isEmpty()) {
+          if (
+            ($paragraph = $reference->entity) &&
+            ($link = $paragraph->localgov_service_url) &&
+            !$link->isEmpty() &&
+            ($url = $link->first()->getUrl()) &&
+            $url->isRouted() &&
+            $url->getRouteName() == 'entity.node.canonical'
+          ) {
+            $linked[] = $url->getRouteParameters()['node'];
+          }
+        }
+      }
     }
     // Sublanding: The links in the paragraphs.
     if ($node->bundle() == 'localgov_services_sublanding') {


### PR DESCRIPTION
Pushing this code to ask some questions, before adding test/upgrade path.

I've included the paragraphs here. Reason: They aren't intended for use anywhere else, paragraphs and dependencies are already required by this module. So it seems to make sense. But I notice that even though I've not got Directories on I have all the paragraphs for Directories. Is the idea to depend on localgov paragraphs and have all paragraphs in use or not in there rather than in the module where they are needed?

I've included in the templates more basic required templates. I'll push the theme ones with the bootstrap classes and link here in a moment. Does this make sense?

Do the field and css classes make sense. If so I can then write some tests. Rather double check first rather than edit them.

Should there be an upgrade path already. At the moment this will install the field new, but won't add it to existing sites. To work like in the future when there are live sites that will update I assume we'll add the field, but disabled.