### PR TITLE
Fix error message as missing parent string not set.

### DIFF
--- a/modules/localgov_services_navigation/src/EntityReferenceValue.php
+++ b/modules/localgov_services_navigation/src/EntityReferenceValue.php
@@ -90,7 +90,7 @@ class EntityReferenceValue {
           $parent_label = ($parent_entity->access('view label')) ? $parent_entity->label() : t('- Restricted access -');
         }
         else {
-          t('- Missing Parent Landing page -');
+          $parent_label = t('- Missing Parent Landing page -');
         }
         $label = $parent_label . ' » ' . $label;
       }


### PR DESCRIPTION
On a page if the sublanding page had it's landing page removed or deleted on loading the page there's an unset variable error:

```
`Notice: Undefined variable: parent_label in Drupal\localgov_services_navigation\EntityReferenceValue::getEntityLabels() (line 95 of modules/contrib/localgov_services/modules/localgov_services_navigation/src/EntityReferenceValue.php).

Drupal\localgov_services_navigation\EntityReferenceValue::getEntityLabels(Array) (Line: 42)
```

The check was there - exactly the same as where you are running the autocomplete. It however wasn't setting the value to a variable.