### PR TITLE
WIP: Add services menu and add service landing pages to it

### DIFF
--- a/modules/localgov_services_landing/config/install/system.menu.localgov-services-menu.yml
+++ b/modules/localgov_services_landing/config/install/system.menu.localgov-services-menu.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: localgov-services-menu
+label: 'Services Menu'
+description: 'List of service landing pages'
+locked: false

--- a/modules/localgov_services_landing/config/optional/block.block.localgov_services_menu.yml
+++ b/modules/localgov_services_landing/config/optional/block.block.localgov_services_menu.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.localgov-services-menu
+  module:
+    - system
+  theme:
+    - localgov_theme
+id: localgov_services_menu
+theme: localgov_theme
+region: secondary_menu
+weight: 0
+provider: null
+plugin: 'system_menu_block:localgov-services-menu'
+settings:
+  id: 'system_menu_block:localgov-services-menu'
+  label: 'Services Menu'
+  provider: system
+  label_display: '0'
+  level: 1
+  depth: 0
+  expand_all_items: false
+visibility: {  }

--- a/modules/localgov_services_landing/localgov_services_landing.install
+++ b/modules/localgov_services_landing/localgov_services_landing.install
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @file
+ * Installation functions for Localgov Services Landing module.
+ */
+
+use Drupal\Core\Database\Database;
+use Drupal\Core\Config\FileStorage;
+use Drupal\node\Entity\NodeType;
+
+/**
+ * Reweight Localgov Services Menu and add third party config.
+ */
+function _localgov_services_landing_weight_and_node_alter() {
+  module_set_weight('localgov_services_landing', 1);
+
+  // Load node type localgov_services_landing.
+  $type = NodeType::load('localgov_services_landing');
+
+  // Update third party settings to add new menu.
+  $available_menus = $type->getThirdPartySetting('menu_ui', 'available_menus');
+  $available_menus[] = 'localgov-services-menu';
+  $type->setThirdPartySetting('menu_ui', 'available_menus', $available_menus);
+  $type->setThirdPartySetting('menu_ui', 'parent', 'localgov-services-menu:');
+  $type->save();
+
+  // Empty table.
+  $database = Database::getConnection();
+  if ($database->schema()->tableExists('cache_container')) {
+    $database->truncate('cache_container')->execute();
+  }
+}
+
+/**
+ * Implements hook_install().
+ */
+function localgov_services_landing_install() {
+  _localgov_services_landing_weight_and_node_alter();
+}
+
+/**
+ * Re-weight localgov_services_landing so it executes after menu.ui.module.
+ */
+function localgov_services_landing_update_8001() {
+
+  // See https://drupal.stackexchange.com/a/276209
+  $config_path     = drupal_get_path('module', 'localgov_services_landing') . '/config/install';
+  $source          = new FileStorage($config_path);
+  $config_storage  = \Drupal::service('config.storage');
+
+  // Get install new field config.
+  $config_storage->write('system.menu.localgov-services-menu', $source->read('system.menu.localgov-services-menu'));
+  $config_storage->write('block.block.localgov_services_menu', $source->read('../optional/block.block.localgov_services_menu'));
+
+  _localgov_services_landing_weight_and_node_alter();
+  // @TODO Add all existing service landing pages to the menu.
+}

--- a/modules/localgov_services_landing/localgov_services_landing.module
+++ b/modules/localgov_services_landing/localgov_services_landing.module
@@ -5,6 +5,8 @@
  * LocalGovDrupal services landing page module file.
  */
 
+use Drupal\Core\Form\FormStateInterface;
+
 /**
  * Implements hook_theme().
  */
@@ -22,4 +24,16 @@ function localgov_services_landing_theme($existing, $type, $theme, $path) {
       ],
     ],
   ];
+}
+
+/**
+ * Implements hook_form_node_localgov_services_landing_form_alter().
+ */
+function localgov_services_landing_form_node_localgov_services_landing_form_alter(&$form, FormStateInterface &$form_state) {
+  // If localgov-services-menu is set as the default parent,
+  // set the menu link to be set by default.
+  if ($form['menu']['link']['menu_parent']['#default_value'] == 'localgov-services-menu:') {
+    $form['menu']['#open'] = TRUE;
+    $form['menu']['enabled']['#default_value'] = TRUE;
+  }
 }


### PR DESCRIPTION
This is using the method of creating a menu and altering the node add form.

Pros: Can be toggled on and off with standard drupal editing behaviour
Cons: Does not work with imports.
Alt method: Update the menu during save.

Still work in progress, more for my discovery on how to update node types
and config.