### PR TITLE
Create a services menu using the deriver plugin method

### DIFF
--- a/modules/localgov_services_landing/config/install/system.menu.localgov-services-menu.yml
+++ b/modules/localgov_services_landing/config/install/system.menu.localgov-services-menu.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: localgov-services-menu
+label: 'Services Menu'
+description: 'List of service landing pages'
+locked: false

--- a/modules/localgov_services_landing/config/optional/block.block.localgov_services_menu.yml
+++ b/modules/localgov_services_landing/config/optional/block.block.localgov_services_menu.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.localgov-services-menu
+  module:
+    - system
+  theme:
+    - localgov_theme
+id: localgov_services_menu
+theme: localgov_theme
+region: secondary_menu
+weight: 0
+provider: null
+plugin: 'system_menu_block:localgov-services-menu'
+settings:
+  id: 'system_menu_block:localgov-services-menu'
+  label: 'Services Menu'
+  provider: system
+  label_display: '0'
+  level: 1
+  depth: 0
+  expand_all_items: false
+visibility: {  }

--- a/modules/localgov_services_landing/localgov_services_landing.install
+++ b/modules/localgov_services_landing/localgov_services_landing.install
@@ -10,7 +10,7 @@ use Drupal\Core\Config\FileStorage;
 use Drupal\node\Entity\NodeType;
 
 /**
- * Re-weight localgov_services_landing so it executes after menu.ui.module.
+ * Install the services menu and block.
  */
 function localgov_services_landing_update_8001() {
 

--- a/modules/localgov_services_landing/localgov_services_landing.install
+++ b/modules/localgov_services_landing/localgov_services_landing.install
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @file
+ * Installation functions for Localgov Services Landing module.
+ */
+
+use Drupal\Core\Database\Database;
+use Drupal\Core\Config\FileStorage;
+use Drupal\node\Entity\NodeType;
+
+/**
+ * Re-weight localgov_services_landing so it executes after menu.ui.module.
+ */
+function localgov_services_landing_update_8001() {
+
+  // See https://drupal.stackexchange.com/a/276209
+  $config_path     = drupal_get_path('module', 'localgov_services_landing') . '/config/install';
+  $source          = new FileStorage($config_path);
+  $config_storage  = \Drupal::service('config.storage');
+
+  // Get install new field config.
+  $config_storage->write('system.menu.localgov-services-menu', $source->read('system.menu.localgov-services-menu'));
+  $config_storage->write('block.block.localgov_services_menu', $source->read('../optional/block.block.localgov_services_menu'));
+
+}

--- a/modules/localgov_services_landing/localgov_services_landing.links.menu.yml
+++ b/modules/localgov_services_landing/localgov_services_landing.links.menu.yml
@@ -1,0 +1,4 @@
+localgov_services_landing.services_landing_link:
+  class: Drupal\localgov_services_landing\Plugin\Menu\ServicesLandingLink
+  deriver: Drupal\localgov_services_landing\Plugin\Derivative\ServicesLandingLink
+  menu_name: localgov-services-menu

--- a/modules/localgov_services_landing/localgov_services_landing.module
+++ b/modules/localgov_services_landing/localgov_services_landing.module
@@ -5,7 +5,6 @@
  * LocalGovDrupal services landing page module file.
  */
 
-use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\NodeInterface;
 
 /**

--- a/modules/localgov_services_landing/localgov_services_landing.module
+++ b/modules/localgov_services_landing/localgov_services_landing.module
@@ -5,6 +5,9 @@
  * LocalGovDrupal services landing page module file.
  */
 
+use Drupal\menu_link_content\Entity\MenuLinkContent;
+use Drupal\node\NodeInterface;
+
 /**
  * Implements hook_theme().
  */
@@ -22,4 +25,34 @@ function localgov_services_landing_theme($existing, $type, $theme, $path) {
       ],
     ],
   ];
+}
+
+/**
+ * Implements hook_node_insert().
+ */
+function localgov_services_landing_node_insert(NodeInterface $node) {
+  $type = $node->bundle();
+  if ($type == 'localgov_services_landing') {
+    _localgov_services_landing_rebuild_menu();
+  }
+}
+
+/**
+ * Implements hook_node_update().
+ */
+function localgov_services_landing_node_update(NodeInterface $node) {
+  $type = $node->bundle();
+  if ($type == 'localgov_services_landing') {
+    _localgov_services_landing_rebuild_menu();
+  }
+}
+
+/**
+ * Rebuild the menu.
+ */
+function _localgov_services_landing_rebuild_menu() {
+  \Drupal::cache('menu')->invalidateAll();
+  // Uncomment below if block cache doesn't clear.
+  // \Drupal::cache('block')->invalidateAll();
+  \Drupal::service('plugin.manager.menu.link')->rebuild();
 }

--- a/modules/localgov_services_landing/src/Plugin/Derivative/ServicesLandingLink.php
+++ b/modules/localgov_services_landing/src/Plugin/Derivative/ServicesLandingLink.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Drupal\localgov_services_landing\Plugin\Derivative;
+
+use Drupal\Component\Plugin\Derivative\DeriverBase;
+use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Derivative class that provides the menu links for the service landing pages.
+ * Source https://www.webomelette.com/dynamic-menu-links-drupal-8-plugin-derivatives
+ */
+class ServicesLandingLink extends DeriverBase implements ContainerDeriverInterface {
+
+   /**
+   * @var EntityTypeManagerInterface $entityTypeManager.
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Creates a ServicesLandingLink instance.
+   *
+   * @param $base_plugin_id
+   * @param EntityTypeManagerInterface $entity_type_manager
+   */
+  public function __construct($base_plugin_id, EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, $base_plugin_id) {
+    return new static(
+      $base_plugin_id,
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDerivativeDefinitions($base_plugin_definition) {
+
+    // Get Node storage and do entity query to find all service landing pages.
+    $node_storage = $this->entityTypeManager->getStorage('node');
+    $service_landing_nids = $node_storage->getQuery()
+                                         ->condition('type', 'localgov_services_landing')
+                                         ->execute();
+
+    // We assume we don't have too many...
+    $service_landing_nodes = $node_storage->loadMultiple($service_landing_nids);
+    $links = [];
+    foreach ($service_landing_nodes as $id => $node) {
+      $links[$id] = [
+        'title' => $node->label(),
+        'route_name' => $node->toUrl()->getRouteName(),
+        'route_parameters' => ['node' => $node->id()]
+      ] + $base_plugin_definition;
+    }
+
+    return $links;
+  }
+}

--- a/modules/localgov_services_landing/src/Plugin/Menu/ServicesLandingLink.php
+++ b/modules/localgov_services_landing/src/Plugin/Menu/ServicesLandingLink.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Drupal\localgov_services_landing\Plugin\Menu;
+
+use Drupal\Core\Menu\MenuLinkDefault;
+
+/**
+ * Represents a menu link for a localgov_services_landing node page.
+ */
+class ServicesLandingLink extends MenuLinkDefault {}


### PR DESCRIPTION
Alternative to #83.

This creates a custom menu link and uses a deriver plugin to find all
localgov_services_landing nodes and add them to the services menu.

Also rebuilds the menu on each landing page node save.

Pros: No need to have the menu editable or reimport menu items, this will always be a menu consiting of every service landing page.
Cons: You cannot edit the menu items (you can reorder and disabled them).

Also would need to resovle caching issues.