### PR TITLE
Hide the title block on the service-status page

### DIFF
--- a/modules/localgov_services_status/localgov_services_status.services.yml
+++ b/modules/localgov_services_status/localgov_services_status.services.yml
@@ -8,3 +8,9 @@ services:
     tags:
       - { name: path_processor_inbound, priority: 50 }
       - { name: path_processor_outbound, priority: 50 }
+  localgov_services_status.page_header:
+    class: Drupal\localgov_services_status\EventSubscriber\PageHeaderSubscriber
+    arguments:
+      - '@path.current'
+    tags:
+      - { name: 'event_subscriber' }

--- a/modules/localgov_services_status/src/EventSubscriber/PageHeaderSubscriber.php
+++ b/modules/localgov_services_status/src/EventSubscriber/PageHeaderSubscriber.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\localgov_services_status\EventSubscriber;
+
+use Drupal\Core\Path\CurrentPathStack;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Drupal\localgov_core\Event\PageHeaderDisplayEvent;
+
+/**
+ * Class PageHeaderSubscriber.
+ *
+ * @package Drupal\localgov_services_status\EventSubscriber
+ */
+class PageHeaderSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Current path service.
+   *
+   * @var \Drupal\Core\Path\CurrentPathStack
+   */
+  protected $currentPathStack;
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\Core\Path\CurrentPathStack $current_path_stack
+   *   Current path service.
+   */
+  public function __construct(CurrentPathStack $current_path_stack) {
+    $this->currentPathStack = $current_path_stack;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      PageHeaderDisplayEvent::EVENT_NAME => ['setPageHeader', 0],
+    ];
+  }
+
+  /**
+   * Hide page header for the /service-status page.
+   */
+  public function setPageHeader(PageHeaderDisplayEvent $event) {
+
+    // Hide page header block.
+    $current_path = $this->currentPathStack->getPath();
+    if ($current_path == '/service-status') {
+      $event->setVisibility(FALSE);
+    }
+  }
+
+}

--- a/modules/localgov_services_status/tests/src/Functional/ServiceStatusTest.php
+++ b/modules/localgov_services_status/tests/src/Functional/ServiceStatusTest.php
@@ -18,11 +18,18 @@ class ServiceStatusTest extends BrowserTestBase {
   use NodeCreationTrait;
 
   /**
-   * Test breadcrumbs in the Standard profile.
+   * Use testing profile.
    *
    * @var string
    */
-  protected $profile = 'localgov';
+  protected $profile = 'testing';
+
+  /**
+   * Use stark theme.
+   *
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'classy';
 
   /**
    * Modules to enable.
@@ -165,8 +172,9 @@ class ServiceStatusTest extends BrowserTestBase {
     $this->assertContains('Test Status 3', $results[2]->getText());
 
     // Check service-status page title.
+    $this->drupalPlaceBlock('localgov_page_header_block');
     $this->assertSession()->responseContains('<h1>Council service updates</h1>');
-    $this->assertNotRegExp('/<h1?.*>Service status<\/h1>/', $this->getSession()->getPage()->getHtml());
+    $this->assertSession()->responseNotMatches('/<h1?.*>Service status<\/h1>/');
 
     // Check sticky on top works.
     $status[3]->setSticky(TRUE);
@@ -233,6 +241,7 @@ class ServiceStatusTest extends BrowserTestBase {
     $this->assertSession()->statusCodeEquals(200);
     $this->assertSession()->pageTextContains('Test Status');
 
+    $this->drupalPlaceBlock('system_breadcrumb_block');
     $status_alias = \Drupal::service('path_alias.manager')->getAliasByPath('/node/' . $status->id());
     $this->assertEqual($status_alias, $alias . '/status/test-status');
     $this->drupalGet($alias . '/status/test-status');

--- a/modules/localgov_services_status/tests/src/Functional/ServiceStatusTest.php
+++ b/modules/localgov_services_status/tests/src/Functional/ServiceStatusTest.php
@@ -22,7 +22,7 @@ class ServiceStatusTest extends BrowserTestBase {
    *
    * @var string
    */
-  protected $profile = 'standard';
+  protected $profile = 'localgov';
 
   /**
    * Modules to enable.
@@ -163,6 +163,10 @@ class ServiceStatusTest extends BrowserTestBase {
     $this->assertContains('Test Status 1', $results[0]->getText());
     $this->assertContains('Test Status 2', $results[1]->getText());
     $this->assertContains('Test Status 3', $results[2]->getText());
+
+    // Check service-status page title.
+    $this->assertSession()->responseContains('<h1>Council service updates</h1>');
+    $this->assertNotRegExp('/<h1?.*>Service status<\/h1>/', $this->getSession()->getPage()->getHtml());
 
     // Check sticky on top works.
     $status[3]->setSticky(TRUE);


### PR DESCRIPTION
There are two headings on the /service-status page. See https://localgovdrupal.agile.coop/service-status

This pull request hides the page header block on that page.

Closes #67 