### PR TITLE
update service landing page template to follow drupal standards a little better

### DIFF
--- a/modules/localgov_services_landing/templates/node--localgov-services-landing--full.html.twig
+++ b/modules/localgov_services_landing/templates/node--localgov-services-landing--full.html.twig
@@ -4,107 +4,134 @@
  * Default node template for localgov_services_landing pages.
  */
 #}
+
 {%
   set classes = [
+    'slp',
     'node',
     'node--type-' ~ node.bundle|clean_class,
     node.isPromoted() ? 'node--promoted',
     node.isSticky() ? 'node--sticky',
     not node.isPublished() ? 'node--unpublished',
     view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
-    'row',
-    'servicehub--contact'
   ]
 %}
 
-{% if content.field_destinations %}
-<section class="container-fluid site-max servicehub--more">
-  {{ content.field_destinations }}
-</section>
-{% endif %}
+<article{{ attributes.addClass(classes) }}>
+  {% if node.field_destinations.value %}
+    <section class="slp__services">
+      {{ content.field_destinations }}
+    </section>
+  {% endif %}
 
-{% if service_updates %}
-{{ service_updates }}
-{% endif %}
+  {% if service_updates %}
+    <div class="slp__updates">
+      {{ service_updates }}
+    </div>
+  {% endif %}
 
-<div class="container-fluid site-max">
-  <article{{ attributes.addClass(classes) }}>
-
-    {% if content.field_email_address|render or content.field_address|render or content.field_opening_hours|render or content.field_phone|render %}
-    <div class="col-md-8">
-      <div class="contact-container">
-        <div class="contact-top">
-          <h2>Contact this service</h2>
-          <div class="row">
-
-            <div class="col-sm-6">
-              <ul>
-                {% if content.field_email_address|render %}
-                <li>
-                  <span class="fa fa-envelope"></span>
-                  <a href="mailto:{{ content.field_email_address|render|striptags }}">Send us a message</a>
-                </li>
-                {% endif %}
-
-                {% if content.field_phone|render|striptags %}
-                <li>
-                  <span class="fa fa-phone"></span>
-                  {{ content.field_phone|render|striptags }}
-                </li>
-                {% endif %}
-              </ul>
-
-              {% if content.field_opening_hours|render %}
-              <p class="opening-times">
-                <h3>Opening times</h3>
-                {{ content.field_opening_hours }}
-              </p>
-              {% endif %}
-            </div>
-
-            <div class="col-sm-6">
-              {% if content.field_address_first_line %}
-              <span class="contact-title"><i class="fa fa-map-marker-alt" aria-hidden="true"></i>{{ content.field_address_first_line }}</span>
-              {% endif %}
-              {% if content.field_address %}
-              <div class="contact-address">
-                {{ content.field_address }}
-                {% if content.field_link_to_map|render|striptags %}
-                <a href="{{ content.field_link_to_map|render|striptags }}" class="external-link" target="_blank">View map</a>
-                {% endif %}
-              </div>
-              {% endif %}
-            </div>
-
-          </div>
-        </div>
-
-        {% if content.field_facebook|render or content.field_twitter|render or content.field_hearing_difficulties_phone|render %}
-        <div class="contact-bottom">
-          {% if content.field_facebook|render or content.field_twitter|render %}
+  {% if 
+    node.field_email_address.value 
+    or node.field_address.value 
+    or node.field_opening_hours.value 
+    or node.field_phone.value 
+    or node.field_facebook.value 
+    or node.field_twitter.value 
+    or node.field_hearing_difficulties_phone.value 
+  %}
+    {# Begin Contact Section #}
+    <div class="slp__contact">
+      {# Begin Contact First #}
+      {% if node.field_email_address.value or node.field_address.value or node.field_opening_hours.value or node.field_phone.value %}
+        <div class="slp__contact-first">
+          <h2>{{ 'Contact this service'|t }}</h2>
           <ul>
-            <li>Find us on</li>
-            {% if content.field_facebook|render %}<li><i class="fab fa-facebook-square" aria-hidden="true"></i><a href="{{ content.field_facebook|render|striptags }}">Facebook</a></li>{% endif %}
-            {% if content.field_twitter|render %}<li><i class="fab fa-twitter-square" aria-hidden="true"></i><a href="{{ content.field_twitter|render|striptags }}">Twitter</a></li>{% endif %}
+            {% if node.field_email_address.value %}
+              <li>
+                <span class="fa fa-envelope"></span>
+                <a href="mailto:{{ content.field_email_address|render|striptags }}">{{ 'Send us a message'|t }}</a>
+              </li>
+            {% endif %}
+
+            {% if node.field_phone.value %}
+              <li>
+                <span class="fa fa-phone"></span>
+                {{ content.field_phone|render|striptags }}
+              </li>
+            {% endif %}
           </ul>
+
+          {% if node.field_opening_hours.value %}
+            <div class="slp__opening-times">
+              <h2>{{ 'Opening times'|t }}</h2>
+              {{ content.field_opening_hours }}
+            </div>
           {% endif %}
-          {% if content.field_hearing_difficulties_phone %}
-          <p>If you have hearing or speech difficulties, please call <strong>{{ content.field_hearing_difficulties_phone }}</strong></p>
+
+          {% if node.field_address_first_line.value %}
+            <span class="slp__contact-title">
+              <i class="fa fa-map-marker-alt" aria-hidden="true"></i>
+              {{ content.field_address_first_line }}
+            </span>
+          {% endif %}
+
+          {% if node.field_address.value %}
+            <div class="slp__contact-address">
+              {{ content.field_address }}
+              {% if node.field_link_to_map.value %}
+                <a href="{{ content.field_link_to_map|render|striptags }}" class="external-link" target="_blank">{{ 'View map'|t }}</a>
+              {% endif %}
+            </div>
           {% endif %}
         </div>
-        {% endif %}
+      {% endif %} {# End Contact First #}
 
-      </div>
-    </div>
-    {% endif %}
+      {# Begin Contact Second #}
+      {% if node.field_facebook.value or node.field_twitter.value or node.field_hearing_difficulties_phone.value %}
+        <div class="slp__contact-second">
+          {% if node.field_facebook.value or node.field_twitter.value %}
+            <h2>{{ 'Find us on'|t }}</h2>
+            <ul>
+              {% if node.field_facebook.value %}
+                <li>
+                  <i class="fab fa-facebook-square" aria-hidden="true"></i>
+                  <a href="{{ content.field_facebook|render|striptags }}">{{ 'Facebook'|t }}</a>
+                </li>
+              {% endif %}
+              {% if node.field_twitter.value %}
+                <li>
+                  <i class="fab fa-twitter-square" aria-hidden="true"></i>
+                  <a href="{{ content.field_twitter|render|striptags }}">{{ 'Twitter'|t }}</a>
+                </li>
+              {% endif %}
+            </ul>
+          {% endif %}
 
-    {% if content.field_popular_topics['#items'] is not empty %}
-    <div class="sidebar col-sm-4">
-      <div class="section">
-        {{ content.field_popular_topics }}
-      </div>
-    </div>
-    {% endif %}
+          {% if node.field_hearing_difficulties_phone.value %}
+            <p>
+              {% trans %}
+                If you have hearing or speech difficulties, please call {{ node.field_hearing_difficulties_phone.value }}.
+              {% endtrans %}
+            </p>
+          {% endif %}
+        </div>
+      {% endif %} {# End Contact Second #}
 
-  </article>
-</div>
+    </div> 
+  {% endif %} {# End Contact Section #}
+
+  {% if node.field_popular_topics.value %}
+    <aside class="slp__sidebar">
+      {{ content.field_popular_topics }}
+    </aside>
+  {% endif %}
+</article>
+
+{% block content_variable %}
+  {#
+    This allows the cache_context to bubble up for us, without having to
+    individually list every field in
+    {{ content|without('field_name', 'field_other_field', 'field_etc') }}
+  #}
+  {% set catch_cache = content|render %}
+{% endblock %}


### PR DESCRIPTION
I don't necessarily expect this PR to get merged, but I think it stands as a good example of how we should write our code to follow Drupal coding standards a little better. This PR

1. Removes servicehub--contact class - we can't assume all pages using this content type are contact pages, and `servicehub--contact` supposes it's a modifier of `.servicehub`, but that class is not present
2. Adds `slp` (service landing page) as the block class to use for each element or modifier
3. Places all content for this template inside the `article` element
4. Places `if` statements around all items, to make sure we don't print empty elements
5. Makes sure all strings are translatable - this will be very important for work in Wales or Scotland
6. Uses BEM naming convention for all block elements - `slp__contact`, `slp__services`, etc
7. Sets the sidebar element in an `aside` element rather than a `div` with role of aside
8. Adds a `catch_cache` variable so cache metadata can bubble up properly since we are not rendering `{{ content }}` anywhere

What I would prefer:

1. If this template didn't hardcode string values for field labels and we just rendered the fields instead
2. If we could render `{{ content }}` so if any extra fields are added by a council in a custom way, they will automatically be printed