### PR TITLE
2.0.1 Release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
           composer global config github-oauth.github.com ${{ github.token }}
 
       - name: Obtain the test target from the repo that triggered this workflow
-        run: composer --working-dir=html require --with-all-dependencies localgovdrupal/${{ github.event.repository.name }}:"${COMPOSER_REF} as ${GIT_BASE}-dev"
+        run: composer --working-dir=html require --with-all-dependencies localgovdrupal/${{ github.event.repository.name }}:"${COMPOSER_REF} as ${GIT_BASE%'.x'}"
         
   phpcs:
     name: Coding standards checks

--- a/composer.json
+++ b/composer.json
@@ -1,17 +1,30 @@
 {
-  "name": "localgovdrupal/localgov_services",
-  "description": "LocalGovDrupal distribution: Services features.",
-  "type": "drupal-module",
-  "homepage": "https://github.com/localgovdrupal/localgov_services",
-  "license": "GPL-2.0-or-later",
-  "minimum-stability": "dev",
-  "require": {
-    "drupal/entity_browser": "^2.5",
-    "drupal/field_group": "~3.0",
-    "drupal/link_attributes": "^1.2",
-    "drupal/pathauto": "~1.0",
-    "localgovdrupal/localgov_paragraphs": "^2.0",
-    "localgovdrupal/localgov_topics": "^1.0",
-    "localgovdrupal/localgov_page_components": "^1.0"
-  }
+    "name": "localgovdrupal/localgov_services",
+    "description": "LocalGovDrupal distribution: Services features.",
+    "type": "drupal-module",
+    "homepage": "https://github.com/localgovdrupal/localgov_services",
+    "license": "GPL-2.0-or-later",
+    "minimum-stability": "dev",
+    "require": {
+        "drupal/condition_field": "^2.0",
+        "drupal/entity_browser": "^2.5",
+        "drupal/field_group": "~3.0",
+        "drupal/link_attributes": "^1.2",
+        "drupal/pathauto": "~1.0",
+        "localgovdrupal/localgov_paragraphs": "^2.0",
+        "localgovdrupal/localgov_topics": "^1.0",
+        "localgovdrupal/localgov_page_components": "^1.0"
+    },
+    "extra": {
+        "enable-patching": true,
+        "composer-exit-on-patch-failure": true,
+        "patchLevel": {
+            "drupal/core": "-p2"
+        },
+        "patches": {
+            "drupal/condition_field": {
+                "Fix schema #3215202": "https://www.drupal.org/files/issues/2021-05-28/configuration-schema-fix-3215202-6.patch"
+            }
+        }
+    }
 }

--- a/modules/localgov_services_status/config/install/core.entity_form_display.node.localgov_services_status.default.yml
+++ b/modules/localgov_services_status/config/install/core.entity_form_display.node.localgov_services_status.default.yml
@@ -3,12 +3,14 @@ status: true
 dependencies:
   config:
     - field.field.node.localgov_services_status.body
-    - field.field.node.localgov_services_status.localgov_services_parent
+    - field.field.node.localgov_services_status.localgov_service_status_visibile
     - field.field.node.localgov_services_status.localgov_service_status
     - field.field.node.localgov_services_status.localgov_service_status_on_landi
     - field.field.node.localgov_services_status.localgov_service_status_on_list
+    - field.field.node.localgov_services_status.localgov_services_parent
     - node.type.localgov_services_status
   module:
+    - condition_field
     - path
     - text
 id: node.localgov_services_status.default
@@ -32,12 +34,6 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-  localgov_services_parent:
-    weight: 2
-    settings: {  }
-    third_party_settings: {  }
-    type: options_select
-    region: content
   localgov_service_status:
     weight: 4
     settings: {  }
@@ -45,18 +41,30 @@ content:
     type: options_select
     region: content
   localgov_service_status_on_landi:
-    weight: 6
+    weight: 7
     settings:
       display_label: true
     third_party_settings: {  }
     type: boolean_checkbox
     region: content
   localgov_service_status_on_list:
-    weight: 7
+    weight: 8
     settings:
       display_label: true
     third_party_settings: {  }
     type: boolean_checkbox
+    region: content
+  localgov_service_status_visibile:
+    weight: 6
+    settings: {  }
+    third_party_settings: {  }
+    type: condition_field_default
+    region: content
+  localgov_services_parent:
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
     region: content
   moderation_state:
     type: moderation_state_default
@@ -66,7 +74,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -74,21 +82,21 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 8
+    weight: 9
     region: content
     third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 11
+    weight: 12
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 9
+    weight: 10
     region: content
     third_party_settings: {  }
   title:

--- a/modules/localgov_services_status/config/install/core.entity_view_display.node.localgov_services_status.message.yml
+++ b/modules/localgov_services_status/config/install/core.entity_view_display.node.localgov_services_status.message.yml
@@ -2,34 +2,35 @@ langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.node.message
     - field.field.node.localgov_services_status.body
-    - field.field.node.localgov_services_status.localgov_service_status_visibile
     - field.field.node.localgov_services_status.localgov_service_status
     - field.field.node.localgov_services_status.localgov_service_status_on_landi
     - field.field.node.localgov_services_status.localgov_service_status_on_list
+    - field.field.node.localgov_services_status.localgov_service_status_visibile
     - field.field.node.localgov_services_status.localgov_services_parent
     - node.type.localgov_services_status
   module:
     - text
     - user
-id: node.localgov_services_status.default
+id: node.localgov_services_status.message
 targetEntityType: node
 bundle: localgov_services_status
-mode: default
+mode: message
 content:
   body:
     label: hidden
-    type: text_default
+    type: text_summary_or_trimmed
     weight: 0
     settings: {  }
     third_party_settings: {  }
     region: content
 hidden:
   content_moderation_control: true
-  localgov_service_status_visibile: true
   links: true
   localgov_service_status: true
   localgov_service_status_on_landi: true
   localgov_service_status_on_list: true
+  localgov_service_status_visibile: true
   localgov_services_parent: true
   search_api_excerpt: true

--- a/modules/localgov_services_status/config/install/core.entity_view_display.node.localgov_services_status.teaser.yml
+++ b/modules/localgov_services_status/config/install/core.entity_view_display.node.localgov_services_status.teaser.yml
@@ -4,10 +4,11 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.localgov_services_status.body
-    - field.field.node.localgov_services_status.localgov_services_parent
+    - field.field.node.localgov_services_status.localgov_service_status_visibile
     - field.field.node.localgov_services_status.localgov_service_status
     - field.field.node.localgov_services_status.localgov_service_status_on_landi
     - field.field.node.localgov_services_status.localgov_service_status_on_list
+    - field.field.node.localgov_services_status.localgov_services_parent
     - node.type.localgov_services_status
   module:
     - text
@@ -31,8 +32,9 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
-  localgov_services_parent: true
+  localgov_service_status_visibile: true
   localgov_service_status: true
   localgov_service_status_on_landi: true
   localgov_service_status_on_list: true
+  localgov_services_parent: true
   search_api_excerpt: true

--- a/modules/localgov_services_status/config/install/core.entity_view_mode.node.message.yml
+++ b/modules/localgov_services_status/config/install/core.entity_view_mode.node.message.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.message
+label: Message
+targetEntityType: node
+cache: true

--- a/modules/localgov_services_status/config/install/field.field.node.localgov_services_status.localgov_service_status_visibile.yml
+++ b/modules/localgov_services_status/config/install/field.field.node.localgov_services_status.localgov_service_status_visibile.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_service_status_visibile
+    - node.type.localgov_services_status
+  module:
+    - condition_field
+id: node.localgov_services_status.localgov_service_status_visibile
+field_name: localgov_service_status_visibile
+entity_type: node
+bundle: localgov_services_status
+label: Visibility
+description: 'Set the visibility of the status message to only show it on specific conditions.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  enabled_plugins:
+    request_path: true
+    'entity_bundle:node': false
+    user_role: false
+field_type: condition_field

--- a/modules/localgov_services_status/config/install/field.storage.node.localgov_service_status_visibile.yml
+++ b/modules/localgov_services_status/config/install/field.storage.node.localgov_service_status_visibile.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - condition_field
+    - node
+id: node.localgov_service_status_visibile
+field_name: localgov_service_status_visibile
+entity_type: node
+type: condition_field
+settings: {  }
+module: condition_field
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/localgov_services_status/config/optional/block.block.localgov_service_status_message.yml
+++ b/modules/localgov_services_status/config/optional/block.block.localgov_service_status_message.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - localgov_services_status
+  theme:
+    - localgov_theme
+id: localgov_service_status_message
+theme: localgov_theme
+region: content_top
+weight: 1
+provider: null
+plugin: localgov_service_status_message
+settings:
+  id: service_status_message
+  label: 'Service status message'
+  provider: localgov_services_status
+  label_display: '0'
+visibility: {  }

--- a/modules/localgov_services_status/localgov_services_status.info.yml
+++ b/modules/localgov_services_status/localgov_services_status.info.yml
@@ -9,5 +9,6 @@ dependencies:
   - drupal:path
   - drupal:text
   - drupal:user
+  - condition_field:condition_field
   - localgov_services:localgov_services_landing
   - localgov_services:localgov_services_navigation

--- a/modules/localgov_services_status/localgov_services_status.module
+++ b/modules/localgov_services_status/localgov_services_status.module
@@ -14,10 +14,19 @@ use Drupal\node\NodeInterface;
  */
 function localgov_services_status_theme($existing, $type, $theme, $path) {
   return [
+    'node__localgov_services_status__message' => [
+      'template' => 'node--localgov-services-status--message',
+      'base hook' => 'node',
+    ],
     'service_status_block' => [
       'variables' => [
         'items' => [],
         'see_all_link' => NULL,
+      ],
+    ],
+    'service_status_message' => [
+      'variables' => [
+        'items' => [],
       ],
     ],
     'service_status_page' => [

--- a/modules/localgov_services_status/src/Plugin/Block/ServiceStatusMessage.php
+++ b/modules/localgov_services_status/src/Plugin/Block/ServiceStatusMessage.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Drupal\localgov_services_status\Plugin\Block;
+
+use Drupal\condition_field\ConditionAccessResolver;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Condition\ConditionManager;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a 'ServiceStatusMessage' block.
+ *
+ * @Block(
+ *  id = "localgov_service_status_message",
+ *  admin_label = @Translation("Service status message"),
+ * )
+ */
+class ServiceStatusMessage extends BlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * Drupal\Core\Condition\ConditionManager definition.
+   *
+   * @var \Drupal\Core\Condition\ConditionManager
+   */
+  protected $pluginManagerCondition;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Visible service status nodes.
+   *
+   * @var \Drupal\node\NodeInterface[]
+   */
+  protected $statusNodes = [];
+
+  /**
+   * Cache contexts for visible service statuses.
+   *
+   * @var string[]
+   */
+  protected $cacheContexts = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('plugin.manager.condition'),
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * Service status message block constructor.
+   *
+   * @param array $configuration
+   *   The plugin configuration.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Condition\ConditionManager $plugin_manager_condition
+   *   The plugin manager condition service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ConditionManager $plugin_manager_condition, EntityTypeManagerInterface $entity_type_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->pluginManagerCondition = $plugin_manager_condition;
+    $this->entityTypeManager = $entity_type_manager;
+
+    // Load service status nodes to display.
+    $nids = $this->entityTypeManager->getStorage('node')->getQuery()
+      ->condition('type', 'localgov_services_status')
+      ->condition('status', 1)
+      ->execute();
+    $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple($nids);
+
+    // Check whether service status is visible for given conditions.
+    foreach ($nodes as $node) {
+      if (!$node->get('localgov_service_status_visibile')->isEmpty()) {
+        $conditions = [];
+        $conditions_config = $node->get('localgov_service_status_visibile')->getValue()[0]['conditions'];
+
+        foreach ($conditions_config as $condition_id => $values) {
+          /** @var \Drupal\Core\Condition\ConditionInterface $condition */
+          $condition = $this->pluginManagerCondition->createInstance($condition_id, $values);
+          $conditions[] = $condition;
+          $this->cacheContexts = Cache::mergeContexts($this->cacheContexts, $condition->getCacheContexts());
+        }
+
+        if (ConditionAccessResolver::checkAccess($conditions, 'or')) {
+          $this->statusNodes[] = $node;
+        }
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $build = [];
+
+    $build['#theme'] = 'service_status_message';
+    $build['#items'] = [];
+    foreach ($this->statusNodes as $node) {
+      $build['#items'][] = $this->entityTypeManager->getViewBuilder('node')->view($node, 'message');
+    }
+    return $build;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function blockAccess(AccountInterface $account) {
+    if (empty($this->statusNodes)) {
+      return AccessResult::neutral();
+    }
+    return AccessResult::allowed();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheContexts() {
+    return Cache::mergeContexts(parent::getCacheContexts(), $this->cacheContexts);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheTags() {
+    // Invalidate cache on changes to localgov_services_status nodes.
+    return Cache::mergeTags(parent::getCacheTags(), ['node_list:localgov_services_status']);
+  }
+
+}

--- a/modules/localgov_services_status/templates/node--localgov-services-status--message.html.twig
+++ b/modules/localgov_services_status/templates/node--localgov-services-status--message.html.twig
@@ -1,0 +1,89 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: (optional) The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: (optional) Themed creation date field.
+ * - author_name: (optional) Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ *
+ * @ingroup themeable
+ */
+#}
+{% if node.localgov_service_status.value == '0-severe-impact' %}
+  {% set alert_class  = 'alert-danger' %}
+{% elseif node.localgov_service_status.value == '1-has-issues' %}
+  {% set alert_class  = 'alert-info' %}
+{% elseif node.localgov_service_status.value == '2-no-issues' %}
+  {% set alert_class  = 'alert-success' %}
+{% endif %}
+{%
+  set classes = [
+    'alert',
+    alert_class,
+    'node--type-' ~ node.bundle|clean_class,
+    view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
+  ]
+%}
+<div{{ attributes.addClass(classes).setAttribute('role', 'alert') }}>
+  {{ content }}
+  <p><a href="{{ url }}" aria-label="{{ 'Read more about alert:'|t }} {{ node.label }}">{{ 'Read more...'|t }}</a></p>
+</div>

--- a/modules/localgov_services_status/templates/service-status-message.html.twig
+++ b/modules/localgov_services_status/templates/service-status-message.html.twig
@@ -1,0 +1,7 @@
+{% if items %}
+<div class="service-status-messages">
+  {% for item in items %}
+    {{ item }}
+  {% endfor %}
+</div>
+{% endif %}

--- a/modules/localgov_services_status/tests/src/Functional/ServiceStatusMessageVisibilityTest.php
+++ b/modules/localgov_services_status/tests/src/Functional/ServiceStatusMessageVisibilityTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Drupal\Tests\localgov_services_status\Functional;
+
+use Drupal\node\NodeInterface;
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests localgov service status messages.
+ *
+ * @group localgov_services
+ */
+class ServiceStatusMessageVisibilityTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $profile = 'testing';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'localgov_services_status',
+  ];
+
+  /**
+   * Test service status message visibility.
+   */
+  public function testServiceStatusMessageVisibility() {
+    $this->drupalPlaceBlock('localgov_service_status_message');
+
+    // Create a landing page.
+    $landing = $this->createNode([
+      'title' => 'Test Service',
+      'type' => 'localgov_services_landing',
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+    $landing_path = \Drupal::service('path_alias.manager')->getAliasByPath('/node/' . $landing->id());
+
+    // Create a status page.
+    $title = $this->randomMachineName(8);
+    $summary = $this->randomMachineName(16);
+    $body = $this->randomMachineName(32);
+    $status = $this->createNode([
+      'type' => 'localgov_services_status',
+      'title' => $title,
+      'body' => [
+        'summary' => $summary,
+        'value' => $body,
+      ],
+      'localgov_services_parent' => ['target_id' => $landing->id()],
+      'localgov_service_status' => ['value' => '0-severe-impact'],
+      'status' => NodeInterface::PUBLISHED,
+      'localgov_service_status_visibile' => [
+        'conditions' => [
+          'request_path' => [
+            'pages' => $landing_path,
+            'negate' => 0,
+          ],
+        ],
+      ],
+    ]);
+
+    // Check visibility on landing page.
+    $this->drupalGet($landing_path);
+    $this->assertSession()->elementExists('css', '.service-status-messages');
+    $this->assertSession()->elementTextContains('css', '.service-status-messages', $summary);
+    $this->assertSession()->elementTextNotContains('css', '.service-status-messages', $title);
+    $this->assertSession()->elementTextNotContains('css', '.service-status-messages', $body);
+    $this->assertSession()->linkByHrefExists(\Drupal::service('path_alias.manager')->getAliasByPath('/node/' . $status->id()));
+
+    // Check visibility on homepage.
+    $this->drupalGet('<front>');
+    $this->assertSession()->elementNotExists('css', '.service-status-messages');
+    $this->assertSession()->pageTextNotContains($summary);
+    $this->assertSession()->pageTextNotContains($title);
+    $this->assertSession()->pageTextNotContains($body);
+
+    // Create another status page.
+    $title2 = 'Another status page';
+    $summary2 = $this->randomMachineName(16);
+    $status2 = $this->createNode([
+      'type' => 'localgov_services_status',
+      'title' => $title2,
+      'body' => [
+        'summary' => $summary2,
+        'value' => '',
+      ],
+      'localgov_service_status' => ['value' => '1-has-issues'],
+      'status' => NodeInterface::PUBLISHED,
+      'localgov_service_status_visibile' => [
+        'conditions' => [
+          'request_path' => [
+            'pages' => $landing_path . "\n<front>",
+            'negate' => 0,
+          ],
+        ],
+      ],
+    ]);
+
+    // This is only necessary in tests.
+    // Block visibility is fine when doing this manually.
+    drupal_flush_all_caches();
+
+    // Check visibility on homepage.
+    $this->drupalGet('<front>');
+    $this->assertSession()->elementExists('css', '.service-status-messages');
+    $this->assertSession()->pageTextNotContains($summary);
+    $this->assertSession()->pageTextContains($summary2);
+
+    // Check visibility on landing page.
+    $this->drupalGet($landing_path);
+    $this->assertSession()->elementTextContains('css', '.service-status-messages', $summary);
+    $this->assertSession()->elementTextContains('css', '.service-status-messages', $summary2);
+    $this->assertSession()->linkByHrefExists(\Drupal::service('path_alias.manager')->getAliasByPath('/node/' . $status2->id()));
+  }
+
+}

--- a/modules/localgov_services_status/tests/src/Kernel/PathTest.php
+++ b/modules/localgov_services_status/tests/src/Kernel/PathTest.php
@@ -29,6 +29,7 @@ class PathTest extends KernelTestBase {
     'system',
     'text',
     'user',
+    'condition_field',
     'localgov_services_status',
     'localgov_services_navigation',
   ];


### PR DESCRIPTION
Adds ability to display service status messages on any page.

Changelog:

#114 @stephen-cox Fix GitHub CI after 2.0.0 release
#115 @stephen-cox Display service status messages on selected pages