### PR TITLE
Make the body field on landing pages not required

### DIFF
--- a/modules/localgov_services_landing/config/install/field.field.node.localgov_services_landing.body.yml
+++ b/modules/localgov_services_landing/config/install/field.field.node.localgov_services_landing.body.yml
@@ -13,11 +13,11 @@ entity_type: node
 bundle: localgov_services_landing
 label: Body
 description: ''
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
   display_summary: true
-  required_summary: true
+  required_summary: false
 field_type: text_with_summary


### PR DESCRIPTION
Fix #150 
Add the same fix as #101.

This also makes the summary not required, but I guess that's a separate discussion.
This only changes the config on fresh installs, as not sure it's safe to do this with existing sites with an update hook. 