### PR TITLE
2.0.12 release

### DIFF
--- a/modules/localgov_services_landing/config/install/core.entity_view_display.node.localgov_services_landing.search_result.yml
+++ b/modules/localgov_services_landing/config/install/core.entity_view_display.node.localgov_services_landing.search_result.yml
@@ -25,16 +25,15 @@ targetEntityType: node
 bundle: localgov_services_landing
 mode: search_result
 content:
-  body:
-    label: hidden
-    type: text_summary_or_trimmed
-    weight: 0
-    settings:
-      trim_length: 600
+  search_api_excerpt:
+    settings: {  }
     third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
+  body: true
   content_moderation_control: true
+  links: true
   localgov_address: true
   localgov_address_first_line: true
   localgov_common_tasks: true
@@ -47,4 +46,3 @@ hidden:
   localgov_phone: true
   localgov_popular_topics: true
   localgov_twitter: true
-  links: true

--- a/modules/localgov_services_page/config/install/core.entity_view_display.node.localgov_services_page.search_result.yml
+++ b/modules/localgov_services_page/config/install/core.entity_view_display.node.localgov_services_page.search_result.yml
@@ -10,8 +10,8 @@ dependencies:
     - field.field.node.localgov_services_page.localgov_override_related_links
     - field.field.node.localgov_services_page.localgov_page_components
     - field.field.node.localgov_services_page.localgov_related_links
-    - field.field.node.localgov_services_page.localgov_topic_classified
     - field.field.node.localgov_services_page.localgov_services_parent
+    - field.field.node.localgov_services_page.localgov_topic_classified
     - node.type.localgov_services_page
   module:
     - text
@@ -21,22 +21,20 @@ targetEntityType: node
 bundle: localgov_services_page
 mode: search_result
 content:
-  body:
-    label: hidden
-    weight: 0
-    type: text_summary_or_trimmed
-    settings:
-      trim_length: 600
+  search_api_excerpt:
+    settings: {  }
     third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
+  body: true
   content_moderation_control: true
+  links: true
   localgov_common_tasks: true
   localgov_download_links: true
   localgov_hide_related_topics: true
   localgov_override_related_links: true
   localgov_page_components: true
   localgov_related_links: true
-  localgov_topic_classified: true
-  links: true
   localgov_services_parent: true
+  localgov_topic_classified: true

--- a/modules/localgov_services_status/config/install/core.entity_view_display.node.localgov_services_status.search_result.yml
+++ b/modules/localgov_services_status/config/install/core.entity_view_display.node.localgov_services_status.search_result.yml
@@ -17,19 +17,16 @@ targetEntityType: node
 bundle: localgov_services_status
 mode: search_result
 content:
-  body:
-    label: hidden
-    type: text_summary_or_trimmed
-    weight: 0
-    settings:
-      trim_length: 600
+  search_api_excerpt:
+    settings: {  }
     third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
+  body: true
   content_moderation_control: true
   links: true
   localgov_service_status: true
   localgov_service_status_on_landi: true
   localgov_service_status_on_list: true
   localgov_services_parent: true
-  search_api_excerpt: true

--- a/modules/localgov_services_sublanding/config/install/core.entity_view_display.node.localgov_services_sublanding.search_result.yml
+++ b/modules/localgov_services_sublanding/config/install/core.entity_view_display.node.localgov_services_sublanding.search_result.yml
@@ -4,8 +4,8 @@ dependencies:
   config:
     - core.entity_view_mode.node.search_result
     - field.field.node.localgov_services_sublanding.body
-    - field.field.node.localgov_services_sublanding.localgov_topics
     - field.field.node.localgov_services_sublanding.localgov_services_parent
+    - field.field.node.localgov_services_sublanding.localgov_topics
     - node.type.localgov_services_sublanding
   module:
     - text
@@ -15,16 +15,14 @@ targetEntityType: node
 bundle: localgov_services_sublanding
 mode: search_result
 content:
-  body:
-    type: text_summary_or_trimmed
+  search_api_excerpt:
+    settings: {  }
+    third_party_settings: {  }
     weight: 0
     region: content
-    label: hidden
-    settings:
-      trim_length: 600
-    third_party_settings: {  }
 hidden:
+  body: true
   content_moderation_control: true
-  localgov_topics: true
   links: true
   localgov_services_parent: true
+  localgov_topics: true


### PR DESCRIPTION
* Add search summary to search highlight result displahy mode

Fix #172

Add the search highlight pseduo field to search result display mode for all service content types.

Note: This will mean that whilst not a hard dependency, we are essentially requiring search_api and only supporting search api for search with this display mode, else it will be an empty display.

* Add test for search view mode with highlight.

Co-authored-by: Finn <finn@agile.coop>