### PR TITLE
Release 2.1.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,13 +24,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        localgov-version:
-          - '2.x'
-        drupal-version:
-          - '~9.3'
-        php-version:
-          - '7.4'
-          - '8.1'
+        include:
+          - localgov-version: '2.x'
+            drupal-version: '~9.4'
+            php-version: '8.1'
+          - localgov-version: '3.x'
+            drupal-version: '~10.0'
+            php-version: '8.1'
 
     steps:
 
@@ -108,13 +108,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        localgov-version:
-          - '2.x'
-        drupal-version:
-          - '~9.3'
-        php-version:
-          - '7.4'
-          - '8.1'
+        include:
+          - localgov-version: '2.x'
+            drupal-version: '~9.4'
+            php-version: '8.1'
+          - localgov-version: '3.x'
+            drupal-version: '~10.0'
+            php-version: '8.1'
 
     steps:
 
@@ -144,13 +144,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        localgov-version:
-          - '2.x'
-        drupal-version:
-          - '~9.3'
-        php-version:
-          - '7.4'
-          - '8.1'
+        include:
+          - localgov-version: '2.x'
+            drupal-version: '~9.4'
+            php-version: '8.1'
+          - localgov-version: '3.x'
+            drupal-version: '~10.0'
+            php-version: '8.1'
 
     steps:
 
@@ -179,13 +179,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        localgov-version:
-          - '2.x'
-        drupal-version:
-          - '~9.3'
-        php-version:
-          - '7.4'
-          - '8.1'
+        include:
+          - localgov-version: '2.x'
+            drupal-version: '~9.4'
+            php-version: '8.1'
+          - localgov-version: '3.x'
+            drupal-version: '~10.0'
+            php-version: '8.1'
 
     steps:
 

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
         "drupal/field_group": "~3.0",
         "drupal/link_attributes": "^1.2",
         "drupal/pathauto": "~1.0",
-        "localgovdrupal/localgov_core": "^2.1",
-        "localgovdrupal/localgov_paragraphs": "^2.0",
-        "localgovdrupal/localgov_topics": "^1.0",
-        "localgovdrupal/localgov_page_components": "^1.0"
+        "localgovdrupal/localgov_core": "^2.12",
+        "localgovdrupal/localgov_page_components": "^1.1",
+        "localgovdrupal/localgov_paragraphs": "^2.3",
+        "localgovdrupal/localgov_topics": "^1.0"
     }
 }

--- a/localgov_services.info.yml
+++ b/localgov_services.info.yml
@@ -1,6 +1,6 @@
 name: 'LocalGov Services: Core'
 description: Base module shared for LocalGov Services. It won't do anything on its own. Enable LocalGov Services Landing page module.
-core_version_requirement: ^9.4
+core_version_requirement: ^9.4 || ^10
 type: module
 package: LocalGov Drupal
 

--- a/modules/localgov_services_landing/localgov_services_landing.info.yml
+++ b/modules/localgov_services_landing/localgov_services_landing.info.yml
@@ -1,6 +1,6 @@
 name: 'LocalGov Services: Landing page'
 description: Top level Services.
-core_version_requirement: ^8.9 || ^9
+core_version_requirement: ^9 || ^10
 type: module
 package: LocalGov Drupal
 

--- a/modules/localgov_services_landing/localgov_services_landing.module
+++ b/modules/localgov_services_landing/localgov_services_landing.module
@@ -5,6 +5,8 @@
  * LocalGovDrupal services landing page module file.
  */
 
+use Drupal\localgov_roles\RolesHelper;
+
 /**
  * Implements hook_theme().
  */
@@ -22,4 +24,58 @@ function localgov_services_landing_theme($existing, $type, $theme, $path) {
       ],
     ],
   ];
+}
+
+/**
+ * Implements hook_localgov_roles_default().
+ */
+function localgov_services_landing_localgov_roles_default(): array {
+
+  // Content editing permissions.
+  $perms = [
+    RolesHelper::EDITOR_ROLE => [
+      'create localgov_services_landing content',
+      'delete any localgov_services_landing content',
+      'delete localgov_services_landing revisions',
+      'delete own localgov_services_landing content',
+      'edit any localgov_services_landing content',
+      'edit own localgov_services_landing content',
+      'revert localgov_services_landing revisions',
+      'view localgov_services_landing revisions',
+    ],
+    RolesHelper::AUTHOR_ROLE => [
+      'create localgov_services_landing content',
+      'delete own localgov_services_landing content',
+      'edit own localgov_services_landing content',
+      'revert localgov_services_landing revisions',
+      'view localgov_services_landing revisions',
+    ],
+    RolesHelper::CONTRIBUTOR_ROLE => [
+      'create localgov_services_landing content',
+      'delete own localgov_services_landing content',
+      'edit own localgov_services_landing content',
+      'view localgov_services_landing revisions',
+    ],
+  ];
+
+  // Content scheduling permissions required by localgov_workflows.
+  if (\Drupal::moduleHandler()->moduleExists('localgov_workflows')) {
+    $perms[RolesHelper::EDITOR_ROLE] = array_merge($perms[RolesHelper::EDITOR_ROLE], [
+      'add scheduled transitions node localgov_services_landing',
+      'reschedule scheduled transitions node localgov_services_landing',
+      'view scheduled transitions node localgov_services_landing',
+    ]);
+    $perms[RolesHelper::AUTHOR_ROLE] = array_merge($perms[RolesHelper::AUTHOR_ROLE], [
+      'add scheduled transitions node localgov_services_landing',
+      'reschedule scheduled transitions node localgov_services_landing',
+      'view scheduled transitions node localgov_services_landing',
+    ]);
+    $perms[RolesHelper::CONTRIBUTOR_ROLE] = array_merge($perms[RolesHelper::CONTRIBUTOR_ROLE], [
+      'add scheduled transitions node localgov_services_landing',
+      'reschedule scheduled transitions node localgov_services_landing',
+      'view scheduled transitions node localgov_services_landing',
+    ]);
+  }
+
+  return $perms;
 }

--- a/modules/localgov_services_navigation/localgov_services_navigation.info.yml
+++ b/modules/localgov_services_navigation/localgov_services_navigation.info.yml
@@ -1,6 +1,6 @@
 name: 'LocalGov Services: Navigation'
 description: Navigation shared by Services Pages, and external pages that link into Services.
-core_version_requirement: ^8.9 || ^9
+core_version_requirement: ^9 || ^10
 type: module
 package: LocalGov Drupal
 

--- a/modules/localgov_services_navigation/localgov_services_navigation.module
+++ b/modules/localgov_services_navigation/localgov_services_navigation.module
@@ -46,9 +46,9 @@ function template_preprocess_localgov_services_navigation_child(&$variables) {
 }
 
 /**
- * Implements hook_field_wiget_WIDGET_ID_alter().
+ * Implements hook_field_widget_single_element_WIDGET_TYPE_form_alter().
  */
-function localgov_services_navigation_field_widget_entity_reference_autocomplete_form_alter(&$element, FormStateInterface $form_state, $context) {
+function localgov_services_navigation_field_widget_single_element_entity_reference_autocomplete_form_alter(&$element, FormStateInterface $form_state, $context) {
   if (!empty($element['target_id']) && $element['target_id']['#selection_handler'] == 'localgov_services') {
     $element['target_id']['#value_callback'] = [
       'Drupal\localgov_services_navigation\EntityReferenceValue',

--- a/modules/localgov_services_navigation/src/Plugin/EntityReferenceSelection/ServicesSelection.php
+++ b/modules/localgov_services_navigation/src/Plugin/EntityReferenceSelection/ServicesSelection.php
@@ -167,7 +167,8 @@ class ServicesSelection extends SelectionPluginBase implements ContainerFactoryP
    */
   public function getReferenceableEntities($match = NULL, $match_operator = 'CONTAINS', $limit = 0) {
     $entities = [];
-    $query = $this->buildEntityQuery($match, $match_operator);
+    $query = $this->buildEntityQuery($match, $match_operator)
+      ->accessCheck(TRUE);
     if ($limit > 0) {
       $query->range(0, $limit);
     }
@@ -265,6 +266,7 @@ class ServicesSelection extends SelectionPluginBase implements ContainerFactoryP
       $entity_type = $this->entityTypeManager->getDefinition('node');
       $query = $this->buildEntityQuery();
       $result = $query
+        ->accessCheck(TRUE)
         ->condition($entity_type->getKey('id'), $ids, 'IN')
         ->execute();
     }

--- a/modules/localgov_services_page/localgov_services_page.info.yml
+++ b/modules/localgov_services_page/localgov_services_page.info.yml
@@ -1,6 +1,6 @@
 name: 'LocalGov Services: Page'
 description: Basic page content within a service.
-core_version_requirement: ^8.9 || ^9
+core_version_requirement: ^9 || ^10
 type: module
 package: LocalGov Drupal
 

--- a/modules/localgov_services_page/localgov_services_page.module
+++ b/modules/localgov_services_page/localgov_services_page.module
@@ -5,6 +5,8 @@
  * LocalGovDrupal Services: Page module file.
  */
 
+use Drupal\localgov_roles\RolesHelper;
+
 /**
  * Implements hook_theme().
  */
@@ -23,4 +25,58 @@ function localgov_services_page_theme() {
       'render element' => 'block',
     ],
   ];
+}
+
+/**
+ * Implements hook_localgov_roles_default().
+ */
+function localgov_services_page_localgov_roles_default(): array {
+
+  // Content editing permissions.
+  $perms =  [
+    RolesHelper::EDITOR_ROLE => [
+      'create localgov_services_page content',
+      'delete any localgov_services_page content',
+      'delete localgov_services_page revisions',
+      'delete own localgov_services_page content',
+      'edit any localgov_services_page content',
+      'edit own localgov_services_page content',
+      'revert localgov_services_page revisions',
+      'view localgov_services_page revisions',
+    ],
+    RolesHelper::AUTHOR_ROLE => [
+      'create localgov_services_page content',
+      'delete own localgov_services_page content',
+      'edit own localgov_services_page content',
+      'revert localgov_services_page revisions',
+      'view localgov_services_page revisions',
+    ],
+    RolesHelper::CONTRIBUTOR_ROLE => [
+      'create localgov_services_page content',
+      'delete own localgov_services_page content',
+      'edit own localgov_services_page content',
+      'view localgov_services_page revisions',
+    ],
+  ];
+
+  // Content scheduling permissions required by localgov_workflows.
+  if (\Drupal::moduleHandler()->moduleExists('localgov_workflows')) {
+    $perms[RolesHelper::EDITOR_ROLE] = array_merge($perms[RolesHelper::EDITOR_ROLE], [
+      'add scheduled transitions node localgov_services_page',
+      'reschedule scheduled transitions node localgov_services_page',
+      'view scheduled transitions node localgov_services_page',
+    ]);
+    $perms[RolesHelper::AUTHOR_ROLE] = array_merge($perms[RolesHelper::AUTHOR_ROLE], [
+      'add scheduled transitions node localgov_services_page',
+      'reschedule scheduled transitions node localgov_services_page',
+      'view scheduled transitions node localgov_services_page',
+    ]);
+    $perms[RolesHelper::CONTRIBUTOR_ROLE] = array_merge($perms[RolesHelper::CONTRIBUTOR_ROLE], [
+      'add scheduled transitions node localgov_services_page',
+      'reschedule scheduled transitions node localgov_services_page',
+      'view scheduled transitions node localgov_services_page',
+    ]);
+  }
+
+  return $perms;
 }

--- a/modules/localgov_services_status/localgov_services_status.info.yml
+++ b/modules/localgov_services_status/localgov_services_status.info.yml
@@ -2,7 +2,7 @@ name: 'LocalGov Services: Status page'
 description: 'Status updates related to a service landing page.'
 package: LocalGov Drupal
 type: module
-core_version_requirement: ^8.9 || ^9
+core_version_requirement: ^9 || ^10
 
 dependencies:
   - drupal:options

--- a/modules/localgov_services_status/localgov_services_status.install
+++ b/modules/localgov_services_status/localgov_services_status.install
@@ -17,8 +17,8 @@ function localgov_services_status_install() {
     // Install default config, as this does not appear to work in the
     // config/optional folder.
     // Discussed on https://www.drupal.org/project/simple_sitemap/issues/3156080
-    $generator = \Drupal::service('simple_sitemap.generator');
-    $generator->setBundleSettings('node', 'localgov_services_status', [
+    $entity_manager = \Drupal::service('simple_sitemap.entity_manager');
+    $entity_manager->setBundleSettings('node', 'localgov_services_status', [
       'index' => TRUE,
       'priority' => 0.5,
     ]);

--- a/modules/localgov_services_status/src/ServiceStatus.php
+++ b/modules/localgov_services_status/src/ServiceStatus.php
@@ -141,7 +141,7 @@ class ServiceStatus {
    */
   public function statusUpdateCount(NodeInterface $landing_node, $hide_from_list, $hide_from_landing): int {
     $query = $this->statusUpdatesQuery($landing_node->id(), $hide_from_list, $hide_from_landing);
-    return $query->count()->accessCheck(TRUE)->execute();
+    return $query->count()->execute();
   }
 
   /**
@@ -162,7 +162,8 @@ class ServiceStatus {
       ->condition('type', 'localgov_services_status')
       ->condition('localgov_services_parent', $landing_nid)
       ->condition('status', NodeInterface::PUBLISHED)
-      ->addTag('node_access');
+      ->addTag('node_access')
+      ->accessCheck(TRUE);
     if ($hide_from_list) {
       $query->condition('localgov_service_status_on_list', 1);
     }

--- a/modules/localgov_services_status/tests/src/Functional/ServiceStatusTest.php
+++ b/modules/localgov_services_status/tests/src/Functional/ServiceStatusTest.php
@@ -29,7 +29,7 @@ class ServiceStatusTest extends BrowserTestBase {
    *
    * {@inheritdoc}
    */
-  protected $defaultTheme = 'classy';
+  protected $defaultTheme = 'stark';
 
   /**
    * Modules to enable.

--- a/modules/localgov_services_sublanding/localgov_services_sublanding.info.yml
+++ b/modules/localgov_services_sublanding/localgov_services_sublanding.info.yml
@@ -1,6 +1,6 @@
 name: 'LocalGov Services: Sub Landing page'
 description: Services second level pages.
-core_version_requirement: ^8.9 || ^9
+core_version_requirement: ^9 || ^10
 type: module
 package: LocalGov Drupal
 

--- a/modules/localgov_services_sublanding/localgov_services_sublanding.module
+++ b/modules/localgov_services_sublanding/localgov_services_sublanding.module
@@ -5,6 +5,8 @@
  * LocalGovDrupal service sub-landing page module file.
  */
 
+use Drupal\localgov_roles\RolesHelper;
+
 /**
  * Implements hook_theme().
  */
@@ -26,6 +28,60 @@ function localgov_services_sublanding_theme($existing, $type, $theme, $path) {
       'base hook' => 'paragraph',
     ],
   ];
+}
+
+/**
+ * Implements hook_localgov_roles_default().
+ */
+function localgov_services_sublanding_localgov_roles_default(): array {
+
+  // Content editing permissions.
+  $perms = [
+    RolesHelper::EDITOR_ROLE => [
+      'create localgov_services_sublanding content',
+      'delete any localgov_services_sublanding content',
+      'delete localgov_services_sublanding revisions',
+      'delete own localgov_services_sublanding content',
+      'edit any localgov_services_sublanding content',
+      'edit own localgov_services_sublanding content',
+      'revert localgov_services_sublanding revisions',
+      'view localgov_services_sublanding revisions',
+    ],
+    RolesHelper::AUTHOR_ROLE => [
+      'create localgov_services_sublanding content',
+      'delete own localgov_services_sublanding content',
+      'edit own localgov_services_sublanding content',
+      'revert localgov_services_sublanding revisions',
+      'view localgov_services_sublanding revisions',
+    ],
+    RolesHelper::CONTRIBUTOR_ROLE => [
+      'create localgov_services_sublanding content',
+      'delete own localgov_services_sublanding content',
+      'edit own localgov_services_sublanding content',
+      'view localgov_services_sublanding revisions',
+    ],
+  ];
+
+  // Content scheduling permissions required by localgov_workflows.
+  if (\Drupal::moduleHandler()->moduleExists('localgov_workflows')) {
+    $perms[RolesHelper::EDITOR_ROLE] = array_merge($perms[RolesHelper::EDITOR_ROLE], [
+      'add scheduled transitions node localgov_services_sublanding',
+      'reschedule scheduled transitions node localgov_services_sublanding',
+      'view scheduled transitions node localgov_services_sublanding',
+    ]);
+    $perms[RolesHelper::AUTHOR_ROLE] = array_merge($perms[RolesHelper::AUTHOR_ROLE], [
+      'add scheduled transitions node localgov_services_sublanding',
+      'reschedule scheduled transitions node localgov_services_sublanding',
+      'view scheduled transitions node localgov_services_sublanding',
+    ]);
+    $perms[RolesHelper::CONTRIBUTOR_ROLE] = array_merge($perms[RolesHelper::CONTRIBUTOR_ROLE], [
+      'add scheduled transitions node localgov_services_sublanding',
+      'reschedule scheduled transitions node localgov_services_sublanding',
+      'view scheduled transitions node localgov_services_sublanding',
+    ]);
+  }
+
+  return $perms;
 }
 
 /**

--- a/tests/src/Functional/PagesIntegrationTest.php
+++ b/tests/src/Functional/PagesIntegrationTest.php
@@ -20,16 +20,14 @@ class PagesIntegrationTest extends BrowserTestBase {
   use CronRunTrait;
 
   /**
-   * Test breadcrumbs in the Standard profile.
-   *
-   * @var string
+   * {@inheritdoc}
    */
-  protected $profile = 'standard';
+  protected $profile = 'testing';
 
   /**
    * {@inheritdoc}
    */
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * A user with permission to bypass content access checks.

--- a/tests/src/Functional/ServicesBlockTest.php
+++ b/tests/src/Functional/ServicesBlockTest.php
@@ -22,7 +22,7 @@ class ServicesBlockTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected $profile = 'localgov';
+  protected $profile = 'testing';
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
* Drupal 10 support

Squashed merge of:

* Alias modules for Drupal 10 support
* Add required permissions using hook_localgov_roles_default
* Use entity_manager service rather than generator when configuring simple_sitemap
* Add access check to entity query
* Added access check to entity query
* Use localgov_topics 1.x-dev
* Use localgov_topics ^1.0
* Fixing tests
* Added workflow permissions for service pages
* Update deprecated hook and revert test to original behaviour. New hook name since 9.2 https://www.drupal.org/node/3180429
* Update versions to new releases.

---------