### PR TITLE
Check for field topic_list_links when checking sub landing link children

### DIFF
--- a/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
+++ b/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
@@ -227,6 +227,12 @@ class EntityChildRelationshipUi implements ContainerInjectionInterface {
           continue;
         }
 
+        // If the paragraph does not have a topic_list_links field then skip.
+        // @todo Check for other link fields.
+        if (!$paragraphs->entity->hasField('topic_list_links')) {
+          continue;
+        }
+
         foreach ($paragraphs->entity->topic_list_links as $link) {
           if (
             !$link->isEmpty() &&


### PR DESCRIPTION
Fix #218

Applies hasField('topic_list_links') to EntityChildRelationshipsUi::referencedChildren.
When editing a service sublanding page, the paragraph might not be the topic list and might not contain the field topic_list_links. So this check allows an early bail out until we decide to check child links by type.
