### PR TITLE
Apply patch to better determine node_access on joins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,13 @@
         "localgovdrupal/localgov_page_components": "^1.1",
         "localgovdrupal/localgov_paragraphs": "^2.3",
         "localgovdrupal/localgov_topics": "^1.0"
+    },
+    "extra": {
+        "enable-patching": true,
+        "patches": {
+            "drupal/core": {
+                "node_access filters out accessible nodes when node is left joined (1349080)" : "https://www.drupal.org/files/issues/2023-06-15/1349080-521.patch"
+            }
+        }
     }
 }


### PR DESCRIPTION
Fix #231 
Fix #147 

Applies the patch in https://www.drupal.org/project/drupal/issues/1349080 comment 521. This allows pages with service_landing pages to be referenced when there are modules that implement node_access.