### PR TITLE
Updated drupal/core patch: node_access filters out accessible nodes when node is left joined (1349080)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,4 +211,4 @@ jobs:
           mkdir -p ./html/web/sites/simpletest && chmod 777 ./html/web/sites/simpletest
           sed -i "s#http://localgov.lndo.site#http://drupal#" ./html/phpunit.xml.dist
           docker exec -t drupal bash -c 'chown docker:docker -R /var/www/html'
-          docker exec -u docker -t drupal bash -c "cd /var/www/html && ./bin/paratest --processes=4 ${{ env.LOCALGOV_DRUPAL_PROJECT_PATH }}"
+          docker exec -u docker -t drupal bash -c "cd /var/www/html && ./bin/paratest --processes=4 /var/www/html/${{ env.LOCALGOV_DRUPAL_PROJECT_PATH }}"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "enable-patching": true,
         "patches": {
             "drupal/core": {
-                "node_access filters out accessible nodes when node is left joined (1349080)" : "https://www.drupal.org/files/issues/2023-06-15/1349080-521.patch"
+                "node_access filters out accessible nodes when node is left joined (1349080)" : "https://www.drupal.org/files/issues/2023-11-27/1349080-537.patch"
             }
         }
     }


### PR DESCRIPTION
We're using an old version of this patch and not @ekes latest version https://www.drupal.org/project/drupal/issues/1349080#comment-15334980

Fixes #237