### PR TITLE
Use overridden title for internal links if set

### DIFF
--- a/modules/localgov_services_sublanding/src/NodeTitleInjector.php
+++ b/modules/localgov_services_sublanding/src/NodeTitleInjector.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\localgov_services_sublanding;
+
+use Drupal\Core\Security\TrustedCallbackInterface;
+
+class NodeTitleInjector implements TrustedCallbackInterface {
+  static function inject(array $element) {
+    $element['title'][0]['#context']['value'] = $element['#localgov_services_title_override'];
+    return $element;
+  }
+
+  public static function trustedCallbacks() {
+    $callbacks[] = 'inject';
+    return $callbacks;
+  }
+}

--- a/modules/localgov_services_sublanding/src/Plugin/Field/FieldFormatter/LinkNodeReference.php
+++ b/modules/localgov_services_sublanding/src/Plugin/Field/FieldFormatter/LinkNodeReference.php
@@ -16,6 +16,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Url;
 use Drupal\link\Plugin\Field\FieldType\LinkItem;
+use Drupal\localgov_services_sublanding\NodeTitleInjector;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -160,7 +161,15 @@ class LinkNodeReference extends FormatterBase implements ContainerFactoryPluginI
         }
       }
       if ($entity) {
-        return $this->buildEntityLink($entity);
+        [$entity_access, $render_array] = $this->buildEntityLink($entity);
+
+        if (!empty($item->getValue()['title'])) {
+          // Override node title with entered title text.
+          $render_array['#localgov_services_title_override'] = $item->getValue()['title'];
+          $render_array['#pre_render'][] = [NodeTitleInjector::class, 'inject'];
+        }
+
+        return [$entity_access, $render_array];
       }
       else {
         $render_array = [


### PR DESCRIPTION
Display "Link text" field (if provided) instead of node title when displaying children on sublanding page.

Fix for #94 