### PR TITLE
Update node_access patch to 10.3 merged commit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "enable-patching": true,
         "patches": {
             "drupal/core": {
-                "node_access filters out accessible nodes when node is left joined (1349080)" : "https://www.drupal.org/files/issues/2023-11-27/1349080-537.patch"
+                "node_access filters out accessible nodes when node is left joined (1349080)" : "https://git.drupalcode.org/project/drupal/-/commit/c271adb.diff"
             }
         }
     }


### PR DESCRIPTION
Fix #245

This should resolve the issue where approvals dashboard breaks after a permissions rebuild.
