### PR TITLE
Add PHP 8.2 testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - localgov-version: '3.x'
-            drupal-version: '~10.0'
-            php-version: '8.1'
+        localgov-version:
+          - '3.x'
+        drupal-version:
+          - '~10.0'
+        php-version:
+          - '8.1'
+          - '8.2'
 
     steps:
 
@@ -105,10 +108,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - localgov-version: '3.x'
-            drupal-version: '~10.0'
-            php-version: '8.1'
+        localgov-version:
+          - '3.x'
+        drupal-version:
+          - '~10.0'
+        php-version:
+          - '8.1'
+          - '8.2'
 
     steps:
 
@@ -138,10 +144,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - localgov-version: '3.x'
-            drupal-version: '~10.0'
-            php-version: '8.1'
+        localgov-version:
+          - '3.x'
+        drupal-version:
+          - '~10.0'
+        php-version:
+          - '8.1'
+          - '8.2'
 
     steps:
 
@@ -170,10 +179,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - localgov-version: '3.x'
-            drupal-version: '~10.0'
-            php-version: '8.1'
+        localgov-version:
+          - '3.x'
+        drupal-version:
+          - '~10.0'
+        php-version:
+          - '8.1'
+          - '8.2'
 
     steps:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,9 +106,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.4'
-            php-version: '8.1'
           - localgov-version: '3.x'
             drupal-version: '~10.0'
             php-version: '8.1'
@@ -142,9 +139,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.4'
-            php-version: '8.1'
           - localgov-version: '3.x'
             drupal-version: '~10.0'
             php-version: '8.1'
@@ -177,9 +171,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.4'
-            php-version: '8.1'
           - localgov-version: '3.x'
             drupal-version: '~10.0'
             php-version: '8.1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.4'
-            php-version: '8.1'
           - localgov-version: '3.x'
             drupal-version: '~10.0'
             php-version: '8.1'


### PR DESCRIPTION
Ref #256

This doesn't remove Drupal 9 module support yet, though it should be considered
since the version of localgov_core is Drupal 10.1 only.
