### PR TITLE
Remove content_moderation from defaults.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,14 @@
         "localgovdrupal/localgov_paragraphs": "^2.3",
         "localgovdrupal/localgov_topics": "^1.0"
     },
+    "require-dev": {
+        "localgovdrupal/localgov_workflows": "^1.3"
+    },
     "extra": {
         "enable-patching": true,
         "patches": {
             "drupal/core": {
-                "node_access filters out accessible nodes when node is left joined (1349080)" : "https://git.drupalcode.org/project/drupal/-/commit/c271adb.diff"
+                "node_access filters out accessible nodes when node is left joined (1349080)": "https://git.drupalcode.org/project/drupal/-/commit/c271adb.diff"
             }
         }
     }

--- a/modules/localgov_services_landing/config/install/core.entity_form_display.node.localgov_services_landing.default.yml
+++ b/modules/localgov_services_landing/config/install/core.entity_form_display.node.localgov_services_landing.default.yml
@@ -19,7 +19,6 @@ dependencies:
     - field.field.node.localgov_services_landing.localgov_twitter
     - node.type.localgov_services_landing
   module:
-    - content_moderation
     - field_group
     - link
     - localgov_services
@@ -294,12 +293,6 @@ content:
     settings:
       size: 60
       placeholder: ''
-    third_party_settings: {  }
-  moderation_state:
-    type: moderation_state_default
-    weight: 9
-    region: content
-    settings: {  }
     third_party_settings: {  }
   path:
     type: path

--- a/modules/localgov_services_landing/config/install/core.entity_view_display.node.localgov_services_landing.default.yml
+++ b/modules/localgov_services_landing/config/install/core.entity_view_display.node.localgov_services_landing.default.yml
@@ -127,7 +127,6 @@ content:
       link_to_entity: false
     third_party_settings: {  }
 hidden:
-  content_moderation_control: true
   localgov_common_tasks: true
   localgov_contact_us_online: true
   localgov_other_team_contacts: true

--- a/modules/localgov_services_landing/config/install/core.entity_view_display.node.localgov_services_landing.search_index.yml
+++ b/modules/localgov_services_landing/config/install/core.entity_view_display.node.localgov_services_landing.search_index.yml
@@ -156,6 +156,5 @@ content:
       link_to_entity: false
     third_party_settings: {  }
 hidden:
-  content_moderation_control: true
   links: true
   search_api_excerpt: true

--- a/modules/localgov_services_landing/config/install/core.entity_view_display.node.localgov_services_landing.search_result.yml
+++ b/modules/localgov_services_landing/config/install/core.entity_view_display.node.localgov_services_landing.search_result.yml
@@ -32,7 +32,6 @@ content:
     region: content
 hidden:
   body: true
-  content_moderation_control: true
   links: true
   localgov_address: true
   localgov_address_first_line: true

--- a/modules/localgov_services_landing/config/install/core.entity_view_display.node.localgov_services_landing.teaser.yml
+++ b/modules/localgov_services_landing/config/install/core.entity_view_display.node.localgov_services_landing.teaser.yml
@@ -34,7 +34,6 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
-  content_moderation_control: true
   localgov_address: true
   localgov_address_first_line: true
   localgov_common_tasks: true

--- a/modules/localgov_services_navigation/tests/src/FunctionalJavascript/LandingPageChildrenTest.php
+++ b/modules/localgov_services_navigation/tests/src/FunctionalJavascript/LandingPageChildrenTest.php
@@ -20,7 +20,7 @@ class LandingPageChildrenTest extends WebDriverTestBase {
   /**
    * {@inheritdoc}
    */
-  protected $defaultTheme = 'stark';
+  protected $defaultTheme = 'claro';
 
   /**
    * A user to edit landing pages.

--- a/modules/localgov_services_page/config/install/core.entity_form_display.node.localgov_services_page.default.yml
+++ b/modules/localgov_services_page/config/install/core.entity_form_display.node.localgov_services_page.default.yml
@@ -13,7 +13,6 @@ dependencies:
     - field.field.node.localgov_services_page.localgov_topic_classified
     - node.type.localgov_services_page
   module:
-    - content_moderation
     - entity_browser
     - field_group
     - link_attributes
@@ -176,12 +175,6 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
-    third_party_settings: {  }
-  moderation_state:
-    type: moderation_state_default
-    weight: 3
-    region: content
-    settings: {  }
     third_party_settings: {  }
   path:
     type: path

--- a/modules/localgov_services_page/config/install/core.entity_view_display.node.localgov_services_page.default.yml
+++ b/modules/localgov_services_page/config/install/core.entity_view_display.node.localgov_services_page.default.yml
@@ -37,7 +37,6 @@ content:
     type: entity_reference_entity_view
     region: content
 hidden:
-  content_moderation_control: true
   localgov_common_tasks: true
   localgov_download_links: true
   localgov_hide_related_topics: true

--- a/modules/localgov_services_page/config/install/core.entity_view_display.node.localgov_services_page.search_index.yml
+++ b/modules/localgov_services_page/config/install/core.entity_view_display.node.localgov_services_page.search_index.yml
@@ -91,7 +91,6 @@ content:
       link: false
     third_party_settings: {  }
 hidden:
-  content_moderation_control: true
   links: true
   localgov_hide_related_topics: true
   localgov_override_related_links: true

--- a/modules/localgov_services_page/config/install/core.entity_view_display.node.localgov_services_page.search_result.yml
+++ b/modules/localgov_services_page/config/install/core.entity_view_display.node.localgov_services_page.search_result.yml
@@ -28,7 +28,6 @@ content:
     region: content
 hidden:
   body: true
-  content_moderation_control: true
   links: true
   localgov_common_tasks: true
   localgov_download_links: true

--- a/modules/localgov_services_page/config/install/core.entity_view_display.node.localgov_services_page.teaser.yml
+++ b/modules/localgov_services_page/config/install/core.entity_view_display.node.localgov_services_page.teaser.yml
@@ -30,7 +30,6 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
-  content_moderation_control: true
   localgov_common_tasks: true
   localgov_download_links: true
   localgov_hide_related_topics: true

--- a/modules/localgov_services_page/localgov_services_page.info.yml
+++ b/modules/localgov_services_page/localgov_services_page.info.yml
@@ -5,7 +5,6 @@ type: module
 package: LocalGov Drupal
 
 dependencies:
-  - drupal:content_moderation
   - drupal:field
   - drupal:link
   - drupal:menu_ui

--- a/modules/localgov_services_status/config/install/core.entity_form_display.node.localgov_services_status.default.yml
+++ b/modules/localgov_services_status/config/install/core.entity_form_display.node.localgov_services_status.default.yml
@@ -11,7 +11,6 @@ dependencies:
     - node.type.localgov_services_status
   module:
     - condition_field
-    - content_moderation
     - path
     - text
 id: node.localgov_services_status.default
@@ -70,12 +69,6 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
-    third_party_settings: {  }
-  moderation_state:
-    type: moderation_state_default
-    weight: 9
-    region: content
-    settings: {  }
     third_party_settings: {  }
   path:
     type: path

--- a/modules/localgov_services_status/config/install/core.entity_view_display.node.localgov_services_status.default.yml
+++ b/modules/localgov_services_status/config/install/core.entity_view_display.node.localgov_services_status.default.yml
@@ -25,7 +25,6 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
-  content_moderation_control: true
   localgov_service_status_visibile: true
   links: true
   localgov_service_status: true

--- a/modules/localgov_services_status/config/install/core.entity_view_display.node.localgov_services_status.message.yml
+++ b/modules/localgov_services_status/config/install/core.entity_view_display.node.localgov_services_status.message.yml
@@ -26,7 +26,6 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
-  content_moderation_control: true
   links: true
   localgov_service_status: true
   localgov_service_status_on_landi: true

--- a/modules/localgov_services_status/config/install/core.entity_view_display.node.localgov_services_status.search_index.yml
+++ b/modules/localgov_services_status/config/install/core.entity_view_display.node.localgov_services_status.search_index.yml
@@ -41,7 +41,6 @@ content:
       link: true
     third_party_settings: {  }
 hidden:
-  content_moderation_control: true
   links: true
   localgov_service_status_on_landi: true
   localgov_service_status_on_list: true

--- a/modules/localgov_services_status/config/install/core.entity_view_display.node.localgov_services_status.search_result.yml
+++ b/modules/localgov_services_status/config/install/core.entity_view_display.node.localgov_services_status.search_result.yml
@@ -24,7 +24,6 @@ content:
     region: content
 hidden:
   body: true
-  content_moderation_control: true
   links: true
   localgov_service_status: true
   localgov_service_status_on_landi: true

--- a/modules/localgov_services_sublanding/config/install/core.entity_form_display.node.localgov_services_sublanding.default.yml
+++ b/modules/localgov_services_sublanding/config/install/core.entity_form_display.node.localgov_services_sublanding.default.yml
@@ -7,7 +7,6 @@ dependencies:
     - field.field.node.localgov_services_sublanding.localgov_topics
     - node.type.localgov_services_sublanding
   module:
-    - content_moderation
     - field_group
     - paragraphs
     - path
@@ -105,12 +104,6 @@ content:
       add_mode: dropdown
       form_display_mode: default
       default_paragraph_type: ''
-    third_party_settings: {  }
-  moderation_state:
-    type: moderation_state_default
-    weight: 4
-    region: content
-    settings: {  }
     third_party_settings: {  }
   path:
     type: path

--- a/modules/localgov_services_sublanding/config/install/core.entity_view_display.node.localgov_services_sublanding.default.yml
+++ b/modules/localgov_services_sublanding/config/install/core.entity_view_display.node.localgov_services_sublanding.default.yml
@@ -25,6 +25,5 @@ content:
     region: content
 hidden:
   body: true
-  content_moderation_control: true
   links: true
   localgov_services_parent: true

--- a/modules/localgov_services_sublanding/config/install/core.entity_view_display.node.localgov_services_sublanding.search_index.yml
+++ b/modules/localgov_services_sublanding/config/install/core.entity_view_display.node.localgov_services_sublanding.search_index.yml
@@ -41,6 +41,5 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
-  content_moderation_control: true
   links: true
   search_api_excerpt: true

--- a/modules/localgov_services_sublanding/config/install/core.entity_view_display.node.localgov_services_sublanding.search_result.yml
+++ b/modules/localgov_services_sublanding/config/install/core.entity_view_display.node.localgov_services_sublanding.search_result.yml
@@ -22,7 +22,6 @@ content:
     region: content
 hidden:
   body: true
-  content_moderation_control: true
   links: true
   localgov_services_parent: true
   localgov_topics: true

--- a/modules/localgov_services_sublanding/config/install/core.entity_view_display.node.localgov_services_sublanding.teaser.yml
+++ b/modules/localgov_services_sublanding/config/install/core.entity_view_display.node.localgov_services_sublanding.teaser.yml
@@ -24,7 +24,6 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
-  content_moderation_control: true
   localgov_topics: true
   links: true
   localgov_services_parent: true

--- a/modules/localgov_services_sublanding/localgov_services_sublanding.info.yml
+++ b/modules/localgov_services_sublanding/localgov_services_sublanding.info.yml
@@ -5,7 +5,6 @@ type: module
 package: LocalGov Drupal
 
 dependencies:
-  - drupal:content_moderation
   - drupal:field
   - drupal:menu_ui
   - drupal:node

--- a/tests/src/Functional/WorkflowsIntegrationTest.php
+++ b/tests/src/Functional/WorkflowsIntegrationTest.php
@@ -2,11 +2,7 @@
 
 namespace Drupal\Tests\localgov_services\Functional;
 
-use Drupal\node\NodeInterface;
 use Drupal\Tests\BrowserTestBase;
-use Drupal\Tests\node\Traits\NodeCreationTrait;
-use Drupal\Tests\system\Functional\Menu\AssertBreadcrumbTrait;
-use Drupal\Tests\Traits\Core\CronRunTrait;
 
 /**
  * Tests localgov services pages working with LocalGov Workflows.
@@ -97,7 +93,6 @@ class WorkflowsIntegrationTest extends BrowserTestBase {
     $form->fillField('edit-body-0-value', 'Service 1 description');
     $form->pressButton('edit-submit');
     // Should default to Draft.
-
     $this->drupalGet('node/add/localgov_services_sublanding');
     $form = $this->getSession()->getPage();
     $form->fillField('edit-title-0-value', 'Sub Service 1');
@@ -106,7 +101,6 @@ class WorkflowsIntegrationTest extends BrowserTestBase {
     $form->fillField('edit-localgov-services-parent-0-target-id', 'Service 1 (1)');
     $form->pressButton('edit-submit');
     // Also Draft.
-
     $this->drupalGet('node/1/edit');
     $form = $this->getSession()->getPage();
     // Check is in Draft.

--- a/tests/src/Functional/WorkflowsIntegrationTest.php
+++ b/tests/src/Functional/WorkflowsIntegrationTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Drupal\Tests\localgov_services\Functional;
+
+use Drupal\node\NodeInterface;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\Tests\system\Functional\Menu\AssertBreadcrumbTrait;
+use Drupal\Tests\Traits\Core\CronRunTrait;
+
+/**
+ * Tests localgov services pages working with LocalGov Workflows.
+ *
+ * @group localgov_services
+ */
+class WorkflowsIntegrationTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $profile = 'testing';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * A user with permission to bypass content access checks.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $adminUser;
+
+  /**
+   * The node storage.
+   *
+   * @var \Drupal\node\NodeStorageInterface
+   */
+  protected $nodeStorage;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'localgov_core',
+    'localgov_services',
+    'localgov_services_landing',
+    'localgov_services_sublanding',
+    'localgov_services_page',
+    'localgov_services_navigation',
+    'localgov_workflows',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->drupalPlaceBlock('system_breadcrumb_block');
+    // LocalGov Workflows includes access and other checks.
+    $this->adminUser = $this->drupalCreateUser([
+      'bypass node access',
+      'administer nodes',
+      'use localgov_editorial transition approve',
+      'use localgov_editorial transition archive',
+      'use localgov_editorial transition archived_draft',
+      'use localgov_editorial transition archived_published',
+      'use localgov_editorial transition create_new_draft',
+      'use localgov_editorial transition publish',
+      'use localgov_editorial transition reject',
+      'use localgov_editorial transition submit_for_review',
+      'view all scheduled transitions',
+      'view any unpublished content',
+      'view latest version',
+    ]);
+    $this->nodeStorage = $this->container->get('entity_type.manager')->getStorage('node');
+  }
+
+  /**
+   * Post and link test, change workflow status.
+   *
+   * Post a service landing page.
+   * Post a service sub landing page, and link to landing page.
+   * Link landing page to sublanding page.
+   * Post a page, put it in the landing and sublanding services.
+   * Link page from sublanding page.
+   */
+  public function testPostLink() {
+    $this->drupalLogin($this->adminUser);
+    $this->drupalGet('node/add/localgov_services_landing');
+    $form = $this->getSession()->getPage();
+    $form->fillField('edit-title-0-value', 'Service 1');
+    $form->fillField('edit-body-0-summary', 'Service 1 summary');
+    $form->fillField('edit-body-0-value', 'Service 1 description');
+    $form->pressButton('edit-submit');
+    // Should default to Draft.
+
+    $this->drupalGet('node/add/localgov_services_sublanding');
+    $form = $this->getSession()->getPage();
+    $form->fillField('edit-title-0-value', 'Sub Service 1');
+    $form->fillField('edit-body-0-summary', 'Sub Service 1 summary');
+    $form->fillField('edit-body-0-value', 'Sub Service 1 description');
+    $form->fillField('edit-localgov-services-parent-0-target-id', 'Service 1 (1)');
+    $form->pressButton('edit-submit');
+    // Also Draft.
+
+    $this->drupalGet('node/1/edit');
+    $form = $this->getSession()->getPage();
+    // Check is in Draft.
+    $state = $form->findField('edit-moderation-state-0-state');
+    $this->assertEquals('draft', $state->getValue());
+    // Change to Published.
+    $state->setValue('published');
+    $form->fillField('edit-localgov-destinations-0-target-id', 'Sub landing 1 (2)');
+    $form->pressButton('edit-submit');
+
+    $this->drupalGet('node/add/localgov_services_page');
+    $assert = $this->assertSession();
+    $form = $this->getSession()->getPage();
+    $form->fillField('edit-title-0-value', 'Service 1 Page 1');
+    $form->fillField('edit-body-0-summary', 'Service 1 summary 1 ');
+    $form->fillField('edit-body-0-value', 'Service 1 description 1');
+    $form->fillField('edit-localgov-services-parent-0-target-id', 'Service 1 » Sub landing 1 (2)');
+    $form->pressButton('edit-submit');
+
+    $this->drupalGet('node/2/edit');
+    $form = $this->getSession()->getPage();
+    $state = $form->findField('edit-moderation-state-0-state');
+    $this->assertEquals('draft', $state->getValue());
+    // Change to Published.
+    $state->setValue('published');
+    $form->fillField('edit-localgov-topics-0-subform-topic-list-links-0-uri', '/node/3');
+    $form->pressButton('edit-submit');
+
+    $assert = $this->assertSession();
+    $assert->pageTextContains('Service 1 Page 1');
+
+    $this->drupalLogout();
+    $this->drupalGet('node/2');
+    $assert->pageTextNotContains('Service 1 Page 1');
+    $this->drupalGet('node/3');
+    $this->assertSession()->statusCodeEquals(403);
+  }
+
+}


### PR DESCRIPTION
Workflow isn't configured within services so an empty config doesn't hepl (and breaks workspaces as such). It should be added with localgov_workflows.

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Removes unused dependency on workflow (content_moderation) and fields that aren't displayed.

## How to test

Install.

Also adds a test to confirm configuration once localgov_workflows _is_ enabled.