### PR TITLE
Fix static anaysis checks

### DIFF
--- a/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
+++ b/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
@@ -198,6 +198,9 @@ class EntityChildRelationshipUi implements ContainerInjectionInterface {
    *
    * @param \Drupal\node\NodeInterface $node
    *   The `localgov_service_landing` or `localgov_service_sublanding`.
+   *
+   * @return array
+   *   Array of node IDs.
    */
   public static function referencedChildren(NodeInterface $node) {
     $linked = [];

--- a/modules/localgov_services_navigation/tests/src/FunctionalJavascript/EntityReferenceServicesAutocompleteTest.php
+++ b/modules/localgov_services_navigation/tests/src/FunctionalJavascript/EntityReferenceServicesAutocompleteTest.php
@@ -4,7 +4,7 @@ namespace Drupal\Tests\localgov_services_navigation\FunctionalJavascript;
 
 use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
 use Drupal\node\NodeInterface;
-use Drupal\Tests\field\Traits\EntityReferenceTestTrait;
+use Drupal\Tests\field\Traits\EntityReferenceFieldCreationTrait;
 use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 
@@ -16,10 +16,7 @@ use Drupal\Tests\node\Traits\NodeCreationTrait;
 class EntityReferenceServicesAutocompleteTest extends WebDriverTestBase {
 
   use ContentTypeCreationTrait;
-  // FIXME: Replace with EntityReferenceFieldCreationTrait when Drupal 10.1 is
-  // end of life.
-  // @phpstan-ignore-next-line.
-  use EntityReferenceTestTrait;
+  use EntityReferenceFieldCreationTrait;
   use NodeCreationTrait;
 
   /**

--- a/modules/localgov_services_navigation/tests/src/Kernel/ChildReferencesTest.php
+++ b/modules/localgov_services_navigation/tests/src/Kernel/ChildReferencesTest.php
@@ -10,7 +10,7 @@ use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\taxonomy\Entity\Term;
-use Drupal\Tests\field\Traits\EntityReferenceTestTrait;
+use Drupal\Tests\field\Traits\EntityReferenceFieldCreationTrait;
 use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\Tests\pathauto\Functional\PathautoTestHelperTrait;
@@ -24,10 +24,7 @@ use Drupal\user\Entity\User;
 class ChildReferencesTest extends KernelTestBase {
 
   use ContentTypeCreationTrait;
-  // FIXME: Replace with EntityReferenceFieldCreationTrait when Drupal 10.1 is
-  // end of life.
-  // @phpstan-ignore-next-line.
-  use EntityReferenceTestTrait;
+  use EntityReferenceFieldCreationTrait;
   use NodeCreationTrait;
   use PathautoTestHelperTrait;
 

--- a/modules/localgov_services_navigation/tests/src/Kernel/ParentFieldPathautoTest.php
+++ b/modules/localgov_services_navigation/tests/src/Kernel/ParentFieldPathautoTest.php
@@ -5,7 +5,7 @@ namespace Drupal\Tests\localgov_services_navigation\Kernel;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\node\NodeInterface;
-use Drupal\Tests\field\Traits\EntityReferenceTestTrait;
+use Drupal\Tests\field\Traits\EntityReferenceFieldCreationTrait;
 use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\Tests\pathauto\Functional\PathautoTestHelperTrait;
@@ -18,10 +18,7 @@ use Drupal\Tests\pathauto\Functional\PathautoTestHelperTrait;
 class ParentFieldPathautoTest extends KernelTestBase {
 
   use ContentTypeCreationTrait;
-  // FIXME: Replace with EntityReferenceFieldCreationTrait when Drupal 10.1 is
-  // end of life.
-  // @phpstan-ignore-next-line.
-  use EntityReferenceTestTrait;
+  use EntityReferenceFieldCreationTrait;
   use NodeCreationTrait;
   use PathautoTestHelperTrait;
 


### PR DESCRIPTION
## What does this change?

* Adds return docstring for EntityChildRelationshipUi::referencedChildren
* Use EntityReferenceFieldCreationTrait rather than the deprecated EntityReferenceTestTrait

## How to test

See all the tests pass.

Fixes #273 