### PR TITLE
Upgrade link attributes to 2.x branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "drupal/condition_field": "^2.0",
         "drupal/entity_browser": "^2.5",
         "drupal/field_group": "~3.0",
-        "drupal/link_attributes": "^1.2",
+        "drupal/link_attributes": "^2.1",
         "drupal/pathauto": "~1.0",
         "localgovdrupal/localgov_core": "^2.12",
         "localgovdrupal/localgov_page_components": "^1.1",


### PR DESCRIPTION
Fix #270

Set min version to 2.1 as 1.x branch unsupported.

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Upgrades to 2.x branch

## How to test

Along with https://github.com/localgovdrupal/localgov_news/pull/116 there should no longer be an unsupported module message.

## How can we measure success?

Link attributes are still present on service pages related links (except they don't actually do anything as localgov_base does not support them), there should be a target option. 
No more unsupported module error messages.

## Have we considered potential risks?

Standard module major upgrade risks apply.

## Images

n/a

## Accessibility

n/a