### PR TITLE
fix: coding standards introduced by latest drupal coder rules

### DIFF
--- a/modules/localgov_services_landing/tests/src/Functional/ServicesLandingPageTest.php
+++ b/modules/localgov_services_landing/tests/src/Functional/ServicesLandingPageTest.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\Tests\localgov_services_landing\Functional;
 
-use Drupal\node\NodeInterface;
-use Drupal\taxonomy\Entity\Term;
 use Drupal\Tests\BrowserTestBase;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\node\NodeInterface;
+use Drupal\taxonomy\Entity\Term;
 
 /**
  * Tests localgov service landing pages.

--- a/modules/localgov_services_navigation/tests/src/FunctionalJavascript/EntityReferenceServicesAutocompleteTest.php
+++ b/modules/localgov_services_navigation/tests/src/FunctionalJavascript/EntityReferenceServicesAutocompleteTest.php
@@ -3,10 +3,10 @@
 namespace Drupal\Tests\localgov_services_navigation\FunctionalJavascript;
 
 use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
-use Drupal\node\NodeInterface;
 use Drupal\Tests\field\Traits\EntityReferenceFieldCreationTrait;
 use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\node\NodeInterface;
 
 /**
  * Tests the output of entity reference autocomplete widgets.

--- a/modules/localgov_services_navigation/tests/src/FunctionalJavascript/LandingPageChildrenTest.php
+++ b/modules/localgov_services_navigation/tests/src/FunctionalJavascript/LandingPageChildrenTest.php
@@ -2,11 +2,11 @@
 
 namespace Drupal\Tests\localgov_services_navigation\FunctionalJavascript;
 
+use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
-use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
 use Drupal\node\NodeInterface;
-use Drupal\Tests\node\Traits\NodeCreationTrait;
 
 /**
  * Tests localgov service landing pages unreferenced children list.

--- a/modules/localgov_services_navigation/tests/src/Kernel/ChildReferencesTest.php
+++ b/modules/localgov_services_navigation/tests/src/Kernel/ChildReferencesTest.php
@@ -2,18 +2,18 @@
 
 namespace Drupal\Tests\localgov_services_navigation\Kernel;
 
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\field\Traits\EntityReferenceFieldCreationTrait;
+use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\Tests\pathauto\Functional\PathautoTestHelperTrait;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
-use Drupal\KernelTests\KernelTestBase;
 use Drupal\localgov_services_navigation\EntityChildRelationshipUi;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\taxonomy\Entity\Term;
-use Drupal\Tests\field\Traits\EntityReferenceFieldCreationTrait;
-use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
-use Drupal\Tests\node\Traits\NodeCreationTrait;
-use Drupal\Tests\pathauto\Functional\PathautoTestHelperTrait;
 use Drupal\user\Entity\User;
 
 /**

--- a/modules/localgov_services_navigation/tests/src/Kernel/ParentFieldPathautoTest.php
+++ b/modules/localgov_services_navigation/tests/src/Kernel/ParentFieldPathautoTest.php
@@ -3,12 +3,12 @@
 namespace Drupal\Tests\localgov_services_navigation\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
-use Drupal\language\Entity\ConfigurableLanguage;
-use Drupal\node\NodeInterface;
 use Drupal\Tests\field\Traits\EntityReferenceFieldCreationTrait;
 use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\Tests\pathauto\Functional\PathautoTestHelperTrait;
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\node\NodeInterface;
 
 /**
  * Kernel test check Services Pathauto.

--- a/modules/localgov_services_page/tests/src/Functional/ServicesPageTest.php
+++ b/modules/localgov_services_page/tests/src/Functional/ServicesPageTest.php
@@ -2,9 +2,9 @@
 
 namespace Drupal\Tests\localgov_services_page\Functional;
 
-use Drupal\node\NodeInterface;
 use Drupal\Tests\BrowserTestBase;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\node\NodeInterface;
 
 /**
  * Tests localgov services pages.

--- a/modules/localgov_services_status/src/PathProcessor.php
+++ b/modules/localgov_services_status/src/PathProcessor.php
@@ -68,7 +68,7 @@ class PathProcessor implements InboundPathProcessorInterface, OutboundPathProces
   /**
    * {@inheritdoc}
    */
-  public function processOutbound($path, &$options = [], Request $request = NULL, BubbleableMetadata $bubbleableMetadata = NULL) {
+  public function processOutbound($path, &$options = [], ?Request $request = NULL, ?BubbleableMetadata $bubbleableMetadata = NULL) {
     assert($this->pathProcessor instanceof OutboundPathProcessorInterface);
 
     // This is the inverse of inbound. Maybe less all-encompassing to swap this

--- a/modules/localgov_services_status/src/Plugin/Block/ServiceStatusMessage.php
+++ b/modules/localgov_services_status/src/Plugin/Block/ServiceStatusMessage.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\localgov_services_status\Plugin\Block;
 
-use Drupal\condition_field\ConditionAccessResolver;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Cache\Cache;
@@ -10,6 +9,7 @@ use Drupal\Core\Condition\ConditionManager;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\condition_field\ConditionAccessResolver;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**

--- a/modules/localgov_services_status/tests/src/Functional/ServiceStatusMessageVisibilityTest.php
+++ b/modules/localgov_services_status/tests/src/Functional/ServiceStatusMessageVisibilityTest.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\Tests\localgov_services_status\Functional;
 
-use Drupal\node\NodeInterface;
 use Drupal\Tests\BrowserTestBase;
+use Drupal\node\NodeInterface;
 
 /**
  * Tests localgov service status messages.

--- a/modules/localgov_services_status/tests/src/Functional/ServiceStatusTest.php
+++ b/modules/localgov_services_status/tests/src/Functional/ServiceStatusTest.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\Tests\localgov_services_status\Functional;
 
-use Drupal\node\NodeInterface;
 use Drupal\Tests\BrowserTestBase;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\Tests\system\Functional\Menu\AssertBreadcrumbTrait;
+use Drupal\node\NodeInterface;
 
 /**
  * Tests localgov service status pages.

--- a/modules/localgov_services_sublanding/tests/src/Functional/LinkFormatterTest.php
+++ b/modules/localgov_services_sublanding/tests/src/Functional/LinkFormatterTest.php
@@ -6,8 +6,8 @@ namespace Drupal\tests\localgov_services_sublanding\Functional;
 
 use Drupal\Component\Utility\Random;
 use Drupal\Core\Url;
-use Drupal\node\NodeInterface;
 use Drupal\Tests\BrowserTestBase;
+use Drupal\node\NodeInterface;
 
 /**
  * Functional tests for the LinkNodeReference field formatter.

--- a/modules/localgov_services_sublanding/tests/src/Functional/ServiceSublandingTest.php
+++ b/modules/localgov_services_sublanding/tests/src/Functional/ServiceSublandingTest.php
@@ -2,9 +2,9 @@
 
 namespace Drupal\Tests\localgov_services_sublanding\Functional;
 
-use Drupal\node\NodeInterface;
 use Drupal\Tests\BrowserTestBase;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\node\NodeInterface;
 
 /**
  * Tests localgov services sub-landing pages.

--- a/modules/localgov_services_sublanding/tests/src/Functional/TopicListBuilderTest.php
+++ b/modules/localgov_services_sublanding/tests/src/Functional/TopicListBuilderTest.php
@@ -2,11 +2,11 @@
 
 namespace Drupal\Tests\localgov_services_sublanding\Functional;
 
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\node\NodeInterface;
 use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\taxonomy\Entity\Term;
-use Drupal\Tests\BrowserTestBase;
-use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Symfony\Component\HttpFoundation\Response;
 
 /**

--- a/modules/localgov_services_sublanding/tests/src/Functional/UnpublishedLinkNodeReferenceTest.php
+++ b/modules/localgov_services_sublanding/tests/src/Functional/UnpublishedLinkNodeReferenceTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Drupal\tests\localgov_services_sublanding\Functional;
 
 use Drupal\Component\Utility\Random;
+use Drupal\Tests\BrowserTestBase;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
-use Drupal\Tests\BrowserTestBase;
 
 /**
  * Functional tests for the LinkNodeReference field formatter.

--- a/tests/src/Functional/PagesIntegrationTest.php
+++ b/tests/src/Functional/PagesIntegrationTest.php
@@ -2,11 +2,11 @@
 
 namespace Drupal\Tests\localgov_services\Functional;
 
-use Drupal\node\NodeInterface;
 use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\Traits\Core\CronRunTrait;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\Tests\system\Functional\Menu\AssertBreadcrumbTrait;
-use Drupal\Tests\Traits\Core\CronRunTrait;
+use Drupal\node\NodeInterface;
 
 /**
  * Tests localgov services pages working together, and with external modules.

--- a/tests/src/Functional/ServicesBlockTest.php
+++ b/tests/src/Functional/ServicesBlockTest.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\Tests\localgov_services\Functional;
 
-use Drupal\node\NodeInterface;
-use Drupal\taxonomy\Entity\Term;
 use Drupal\Tests\BrowserTestBase;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\node\NodeInterface;
+use Drupal\taxonomy\Entity\Term;
 
 /**
  * Functional tests for LocalGovDrupal install profile.


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

This fixes the following coding standards that are now enabled by drupal coder

- https://www.drupal.org/project/coder/issues/3470716
- https://www.drupal.org/node/3471146