### PR TITLE
Remove the unused $build theme page_header

### DIFF
--- a/modules/localgov_services_status/src/Controller/ServiceStatusPageController.php
+++ b/modules/localgov_services_status/src/Controller/ServiceStatusPageController.php
@@ -71,11 +71,6 @@ class ServiceStatusPageController extends ControllerBase {
     $build = [];
 
     $build[] = [
-      '#theme' => 'page_header',
-      '#title' => $this->t('Latest service updates'),
-    ];
-
-    $build[] = [
       '#theme' => 'service_status_page',
       '#items' => $this->serviceStatus->getStatusForPage($node),
     ];


### PR DESCRIPTION
Fix #289

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Remove the old page_header from the $build array of the service status page controller. This was a left over way of adding the page header from BHCC Drupal 8 / Miggle site and was never used in Localgov Drupal. It's presence was causing a `Theme hook page_header not found` warning in watchdog.

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test

Access a service status page eg. On demo content at /adult-health-and-social-care/status
Then check the log and make sure no warning is logged.

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

No more warnings.
<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?

If someone has this template and is using it, now they won't have the text 'latest services status' added to it.
Note: This template only exists as a hold over on the BHCC site, it is not present at all in Localgov Drupal.

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images
n/a.

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

n/a.