### PR TITLE
Remove node access patch as 10.2 no longer supported

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,5 @@
     },
     "require-dev": {
         "localgovdrupal/localgov_workflows": "^1.3"
-    },
-    "extra": {
-        "enable-patching": true,
-        "patches": {
-            "drupal/core": {
-                "node_access filters out accessible nodes when node is left joined (1349080)": "https://git.drupalcode.org/project/drupal/-/commit/c271adb.diff"
-            }
-        }
     }
 }


### PR DESCRIPTION
Fix #263
Fix #292

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Remove the patch "node_access filters out accessible nodes when node is left joined (1349080)"
This patch will still be required for Drupal installs <10.3, but they should no longer be used.

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test

As per the original issue, #231 and #147.
Install a module that uses a node_access hook. Eg. [View unpublished](https://www.drupal.org/project/view_unpublished).

Try to create a service page and service landing page, users should still be able to reference a serivce landing page in the parent if they have persmission to view it.
(Will require using the editor role).

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Cleaner deploys, service page structure remains intact.

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?

Councils may be staying on 10.2 which is now unsupported, they will need to reapply the patch.

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images

n/a

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

n/a