### PR TITLE
feat: drupal 11 support

### DIFF
--- a/localgov_services.info.yml
+++ b/localgov_services.info.yml
@@ -1,6 +1,6 @@
 name: 'LocalGov Services: Core'
 description: Base module shared for LocalGov Services. It won't do anything on its own. Enable LocalGov Services Landing page module.
-core_version_requirement: ^9.4 || ^10
+core_version_requirement: ^10 || ^11
 type: module
 package: LocalGov Drupal
 

--- a/modules/localgov_services_landing/localgov_services_landing.info.yml
+++ b/modules/localgov_services_landing/localgov_services_landing.info.yml
@@ -1,6 +1,6 @@
 name: 'LocalGov Services: Landing page'
 description: Top level Services.
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 type: module
 package: LocalGov Drupal
 

--- a/modules/localgov_services_navigation/localgov_services_navigation.info.yml
+++ b/modules/localgov_services_navigation/localgov_services_navigation.info.yml
@@ -1,6 +1,6 @@
 name: 'LocalGov Services: Navigation'
 description: Navigation shared by Services Pages, and external pages that link into Services.
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 type: module
 package: LocalGov Drupal
 

--- a/modules/localgov_services_page/localgov_services_page.info.yml
+++ b/modules/localgov_services_page/localgov_services_page.info.yml
@@ -1,6 +1,6 @@
 name: 'LocalGov Services: Page'
 description: Basic page content within a service.
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 type: module
 package: LocalGov Drupal
 

--- a/modules/localgov_services_status/localgov_services_status.info.yml
+++ b/modules/localgov_services_status/localgov_services_status.info.yml
@@ -2,7 +2,7 @@ name: 'LocalGov Services: Status page'
 description: 'Status updates related to a service landing page.'
 package: LocalGov Drupal
 type: module
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 
 dependencies:
   - drupal:options

--- a/modules/localgov_services_sublanding/localgov_services_sublanding.info.yml
+++ b/modules/localgov_services_sublanding/localgov_services_sublanding.info.yml
@@ -1,6 +1,6 @@
 name: 'LocalGov Services: Sub Landing page'
 description: Services second level pages.
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 type: module
 package: LocalGov Drupal
 


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Fixes #280 

## How to test

```bash
localgovdrupal/localgov_services:"dev-feature/2.x/drupal-11-support as 2.1.15"
```

Failures are eslint and stylelint, not related to D11 support.

## How can we measure success?

Module works with both D10 and D11