### PR TITLE
fix: replace internal NodeForm

### DIFF
--- a/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
+++ b/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
@@ -126,7 +126,9 @@ class EntityChildRelationshipUi implements ContainerInjectionInterface {
     }
 
     $node = $form_object->getEntity();
-    assert($node instanceof NodeInterface);
+    if (!$node instanceof NodeInterface) {
+      return;
+    }
 
     if (in_array($node->bundle(), [
       'localgov_services_landing',

--- a/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
+++ b/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
@@ -120,7 +120,7 @@ class EntityChildRelationshipUi implements ContainerInjectionInterface {
   public function formAlter(array &$form, FormStateInterface $form_state, $form_id) {
     $form_object = $form_state->getFormObject();
 
-     // Must be a content entity form on a node.
+    // Must be a content entity form on a node.
     if (!$form_object instanceof ContentEntityFormInterface) {
       return;
     }
@@ -129,9 +129,9 @@ class EntityChildRelationshipUi implements ContainerInjectionInterface {
     assert($node instanceof NodeInterface);
 
     if (in_array($node->bundle(), [
-        'localgov_services_landing',
-        'localgov_services_sublanding',
-      ]) &&
+      'localgov_services_landing',
+      'localgov_services_sublanding',
+    ]) &&
       $node->id()
     ) {
       $form['localgov_services_navigation_children'] = [

--- a/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
+++ b/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
@@ -4,6 +4,7 @@ namespace Drupal\localgov_services_navigation;
 
 use Drupal\Component\Utility\Html;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\ContentEntityFormInterface;
 use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
@@ -11,7 +12,6 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
-use Drupal\node\NodeForm;
 use Drupal\node\NodeInterface;
 use Drupal\taxonomy\TermInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -119,10 +119,16 @@ class EntityChildRelationshipUi implements ContainerInjectionInterface {
    */
   public function formAlter(array &$form, FormStateInterface $form_state, $form_id) {
     $form_object = $form_state->getFormObject();
-    if (
-      $form_object instanceof NodeForm &&
-      ($node = $form_object->getEntity()) &&
-      in_array($node->bundle(), [
+
+     // Must be a content entity form on a node.
+    if (!$form_object instanceof ContentEntityFormInterface) {
+      return;
+    }
+
+    $node = $form_object->getEntity();
+    assert($node instanceof NodeInterface);
+
+    if (in_array($node->bundle(), [
         'localgov_services_landing',
         'localgov_services_sublanding',
       ]) &&

--- a/modules/localgov_services_navigation/tests/src/Kernel/ChildReferencesTest.php
+++ b/modules/localgov_services_navigation/tests/src/Kernel/ChildReferencesTest.php
@@ -278,8 +278,8 @@ class ChildReferencesTest extends KernelTestBase {
     $node->save();
 
     // Mock node form and form state classes.
-    $methods = get_class_methods('Drupal\node\NodeForm');
-    $node_form = $this->getMockBuilder('Drupal\node\NodeForm')
+    $methods = get_class_methods('Drupal\Core\Entity\ContentEntityFormInterface');
+    $node_form = $this->getMockBuilder('Drupal\Core\Entity\ContentEntityFormInterface')
       ->disableOriginalConstructor()
       ->onlyMethods($methods)
       ->getMock();


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Fixes #310. NodeForm is internal and has moved location in Drupal 11.2. The change in this PR allows support for Drupal 10.x and 11.x

This PR follows a similar fix as in https://github.com/localgovdrupal/localgov_news/pull/144