### PR TITLE
Entity Query access control to decide if users can reference content.

### DIFF
--- a/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
+++ b/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
@@ -153,6 +153,12 @@ class EntityChildRelationshipUi implements ContainerInjectionInterface {
     $children_query->condition('localgov_services_parent', $node->id());
     // Exclude status which automatically get addded to page seperately.
     $children_query->condition('type', 'localgov_services_status', '<>');
+    // Only allow access to published nodes if the user does not have the
+    // bypass node access, view any unpublished permission, or there are
+    // implementation of hook_node_grants which will add the node_access table.
+    if (!$this->currentUser->hasPermission('bypass node access') && !$this->currentUser->hasPermission('view any unpublished content') && !$this->moduleHandler->hasImplementations('node_grants')) {
+      $children_query->condition('status', NodeInterface::PUBLISHED);
+    }
     $children = $children_query->accessCheck(TRUE)->execute();
 
     $unreferenced_children = array_diff($children, self::referencedChildren($node));

--- a/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
+++ b/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
@@ -153,9 +153,6 @@ class EntityChildRelationshipUi implements ContainerInjectionInterface {
     $children_query->condition('localgov_services_parent', $node->id());
     // Exclude status which automatically get addded to page seperately.
     $children_query->condition('type', 'localgov_services_status', '<>');
-    if (!$this->currentUser->hasPermission('bypass node access') && !$this->moduleHandler->hasImplementations('node_grants')) {
-      $children_query->condition('status', NodeInterface::PUBLISHED);
-    }
     $children = $children_query->accessCheck(TRUE)->execute();
 
     $unreferenced_children = array_diff($children, self::referencedChildren($node));

--- a/modules/localgov_services_navigation/src/Plugin/EntityReferenceSelection/ServicesSelection.php
+++ b/modules/localgov_services_navigation/src/Plugin/EntityReferenceSelection/ServicesSelection.php
@@ -12,7 +12,6 @@ use Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**

--- a/modules/localgov_services_navigation/src/Plugin/EntityReferenceSelection/ServicesSelection.php
+++ b/modules/localgov_services_navigation/src/Plugin/EntityReferenceSelection/ServicesSelection.php
@@ -12,6 +12,7 @@ use Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -233,6 +234,18 @@ class ServicesSelection extends SelectionPluginBase implements ContainerFactoryP
     $query->sort('title', 'ASC');
     $query->addTag('entity_reference');
     $query->addMetaData('entity_reference_selection_handler', $this);
+
+    // Adding the 'node_access' tag is sadly insufficient for nodes: core
+    // requires us to also know about the concept of 'published' and
+    // 'unpublished'. We need to do that as long as there are no access control
+    // modules in use on the site. As long as one access control module is
+    // there, it is supposed to handle this check.
+    // Additionally, if the user has the permission
+    // 'view any unpublished content' from Content moderation,
+    // don't restrict access.
+    if (!$this->currentUser->hasPermission('bypass node access') && !$this->currentUser->hasPermission('view any unpublished content') && !$this->moduleHandler->hasImplementations('node_grants')) {
+      $query->condition('status', NodeInterface::PUBLISHED);
+    }
     return $query;
   }
 

--- a/modules/localgov_services_navigation/src/Plugin/EntityReferenceSelection/ServicesSelection.php
+++ b/modules/localgov_services_navigation/src/Plugin/EntityReferenceSelection/ServicesSelection.php
@@ -167,8 +167,7 @@ class ServicesSelection extends SelectionPluginBase implements ContainerFactoryP
    */
   public function getReferenceableEntities($match = NULL, $match_operator = 'CONTAINS', $limit = 0) {
     $entities = [];
-    $query = $this->buildEntityQuery($match, $match_operator)
-      ->accessCheck(TRUE);
+    $query = $this->buildEntityQuery($match, $match_operator);
     if ($limit > 0) {
       $query->range(0, $limit);
     }
@@ -219,6 +218,7 @@ class ServicesSelection extends SelectionPluginBase implements ContainerFactoryP
     $configuration = $this->getConfiguration();
     $entity_type = $this->entityTypeManager->getDefinition('node');
     $query = $this->entityTypeManager->getStorage('node')->getQuery();
+    $query->accessCheck(TRUE);
     $query->condition($entity_type->getKey('bundle'), $configuration['target_bundles'], 'IN');
 
     if (isset($match)) {
@@ -232,15 +232,6 @@ class ServicesSelection extends SelectionPluginBase implements ContainerFactoryP
     }
     $query->sort('localgov_services_parent.entity:node.title', 'ASC');
     $query->sort('title', 'ASC');
-    $query->addTag('node_access');
-    // Adding the 'node_access' tag is sadly insufficient for nodes: core
-    // requires us to also know about the concept of 'published' and
-    // 'unpublished'. We need to do that as long as there are no access control
-    // modules in use on the site. As long as one access control module is
-    // there, it is supposed to handle this check.
-    if (!$this->currentUser->hasPermission('bypass node access') && !$this->moduleHandler->hasImplementations('node_grants')) {
-      $query->condition('status', NodeInterface::PUBLISHED);
-    }
     $query->addTag('entity_reference');
     $query->addMetaData('entity_reference_selection_handler', $this);
     return $query;

--- a/modules/localgov_services_navigation/tests/src/FunctionalJavascript/EntityReferenceServicesAutocompleteTest.php
+++ b/modules/localgov_services_navigation/tests/src/FunctionalJavascript/EntityReferenceServicesAutocompleteTest.php
@@ -20,6 +20,13 @@ class EntityReferenceServicesAutocompleteTest extends WebDriverTestBase {
   use NodeCreationTrait;
 
   /**
+   * A user with access to all content.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $admin;
+
+  /**
    * A user with mininum permissions for test.
    *
    * @var \Drupal\user\UserInterface
@@ -53,6 +60,10 @@ class EntityReferenceServicesAutocompleteTest extends WebDriverTestBase {
   protected function setUp(): void {
     parent::setUp();
 
+    $this->admin = $this->drupalCreateUser([
+      'bypass node access',
+    ]);
+
     // Create a Content type and two test nodes.
     $this->createContentType(['type' => 'page']);
     $this->createNode([
@@ -65,6 +76,13 @@ class EntityReferenceServicesAutocompleteTest extends WebDriverTestBase {
       'type' => 'localgov_services_sublanding',
       'localgov_services_parent' => ['target_id' => 1],
       'status' => NodeInterface::PUBLISHED,
+    ]);
+    $this->createNode([
+      'title' => 'Unpublished Page Sub',
+      'type' => 'localgov_services_sublanding',
+      'localgov_services_parent' => ['target_id' => 1],
+      'status' => NodeInterface::NOT_PUBLISHED,
+      'uid' => $this->admin->id(),
     ]);
 
     $this->user = $this->drupalCreateUser([
@@ -114,7 +132,7 @@ class EntityReferenceServicesAutocompleteTest extends WebDriverTestBase {
     // Return the landing page, not another sublanding page.
     $assert_session->pageTextContains('Landing Page 1');
     $assert_session->pageTextContains('Landing Page 1 » Page Sub 1');
-
+    $assert_session->pageTextNotContains('Landing Page 1 » Unpublished Page Sub');
   }
 
   /**

--- a/modules/localgov_services_navigation/tests/src/FunctionalJavascript/LandingPageChildrenTest.php
+++ b/modules/localgov_services_navigation/tests/src/FunctionalJavascript/LandingPageChildrenTest.php
@@ -23,6 +23,13 @@ class LandingPageChildrenTest extends WebDriverTestBase {
   protected $defaultTheme = 'claro';
 
   /**
+   * A user to access all content.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $admin;
+
+  /**
    * A user to edit landing pages.
    *
    * @var \Drupal\user\UserInterface
@@ -56,6 +63,9 @@ class LandingPageChildrenTest extends WebDriverTestBase {
       'label' => $this->randomMachineName(),
     ]);
     $field_instance->save();
+    $this->admin = $this->drupalCreateUser([
+      'bypass node access',
+    ]);
     $this->user = $this->drupalCreateUser([
       'access content',
       'create page content',
@@ -108,6 +118,15 @@ class LandingPageChildrenTest extends WebDriverTestBase {
     ]);
     $child[3]->save();
 
+    $child[3] = $this->createNode([
+      'title' => 'unpublished page',
+      'type' => 'page',
+      'localgov_services_parent' => ['target_id' => $landing->id()],
+      'status' => NodeInterface::NOT_PUBLISHED,
+      'uid' => $this->admin->id(),
+    ]);
+    $child[3]->save();
+
     $this->drupalGet($landing->toUrl('edit-form')->toString());
     $page = $this->getSession()->getPage();
     $assert_session = $this->assertSession();
@@ -149,6 +168,8 @@ class LandingPageChildrenTest extends WebDriverTestBase {
     $assert_session->fieldValueEquals('edit-localgov-common-tasks-1-uri', '/foo');
     $assert_session->fieldValueEquals('edit-localgov-common-tasks-1-title', '\'; #child_2\n');
 
+    // The unpublished node cannot be seen.
+    $assert_session->elementNotExists('css', '#localgov-child-drag-' . $child[4]->id());
   }
 
   /**


### PR DESCRIPTION
https://github.com/localgovdrupal/localgov_services/issues/216#issuecomment-3223678278

Adds tests. I think they're failing, because I think they do get the content in the list.

Pushing for work done. @andybroomfield 