### PR TITLE
Rewrite services js to use es6 and remove jQuery

### DIFF
--- a/modules/localgov_services_navigation/js/children.js
+++ b/modules/localgov_services_navigation/js/children.js
@@ -15,109 +15,135 @@
  * content for different field types, so for more compatibility maybe an
  * additional library would be required.
  */
-(function ($, Drupal) {
-
-  var dragChild;
+(function localgovServiceChildScript(Drupal, once) {
+  let dragChild;
 
   Drupal.behaviors.localgovServiceChild = {
-    attach: function attach(context, settings) {
+    attach: function attach(context) {
       // Add draggability to child items.
-      var child = $('.localgov-child-drag');
-      child.each(function() {
-        this.setAttribute('draggable', true);
-        this.classList.add('draggable');
-        this.addEventListener('dragstart', function (event) {
-          event.dataTransfer.dropEffect = "move";
-          event.dataTransfer.effectAllowed = "move";
-          dragChild = this;
+      const children = once(
+        'allServicesChildren',
+        '.localgov-child-drag',
+        context,
+      );
+      if (children) {
+        children.forEach((child) => {
+          child.setAttribute('draggable', true);
+          child.classList.add('draggable');
+          child.addEventListener('dragstart', (event) => {
+            event.dataTransfer.dropEffect = 'move';
+            event.dataTransfer.effectAllowed = 'move';
+            dragChild = child;
+          });
         });
-      });
-    }
+      }
+    },
   };
 
   Drupal.behaviors.localgovServiceTaskDrop = {
-    attach: function attach(context, settings) {
+    attach: function attach(context) {
       // Is it always a table. Maybe form-item and then parent?
-      var linkRow = $("[data-drupal-selector='edit-localgov-common-tasks'] tr");
-      linkRow.each(function() {
-        this.addEventListener('dragover', function (event) {
-          var row = $(event.target).closest('tr');
-          var url = $("input[data-drupal-selector$=uri]", row);
-          if (url.val() == '') {
+      const linkRows = once(
+        'allServicesLinkRows',
+        '[data-drupal-selector="edit-localgov-common-tasks"] tr',
+        context,
+      );
+      linkRows.forEach((row) => {
+        row.addEventListener('dragover', (event) => {
+          const targetRow = event.target.closest('tr');
+          const url = targetRow.querySelector(
+            'input[data-drupal-selector$=uri]',
+          );
+          if (url.value === '') {
             event.preventDefault();
-            event.dataTransfer.dropEffect = "move";
+            event.dataTransfer.dropEffect = 'move';
           }
         });
-        this.addEventListener('drop', function(event) {
-          var row = $(event.target).closest('tr');
-          var url = $("input[data-drupal-selector$=uri]", row);
-          if (url.val() == '') {
+        row.addEventListener('drop', (event) => {
+          const targetRow = event.target.closest('tr');
+          const url = targetRow.querySelector(
+            'input[data-drupal-selector$=uri]',
+          );
+          if (url.value === '') {
             event.preventDefault();
-            var title = $("input[data-drupal-selector$=title]", row);
-            title.val(dragChild.getAttribute('data-localgov-title'));
-            url.val(dragChild.getAttribute('data-localgov-url'));
-            $(dragChild).remove();
+            const title = targetRow.querySelector(
+              'input[data-drupal-selector$=title]',
+            );
+            title.value = dragChild.getAttribute('data-localgov-title');
+            url.value = dragChild.getAttribute('data-localgov-url');
+            dragChild.remove();
           }
         });
       });
-    }
+    },
   };
 
   Drupal.behaviors.localgovServiceChildDrop = {
-    attach: function attach(context, settings) {
-      var linkRow = $("[data-drupal-selector='edit-localgov-destinations'] tr");
-      linkRow.each(function() {
-        this.addEventListener('dragover', function (event) {
-          var row = $(event.target).closest('tr');
-          var ref = $("input[data-drupal-selector$=target-id]", row);
-          if (ref.val() == '') {
+    attach: function attach(context) {
+      const linkRows = once(
+        'allServicesLinkRows',
+        '[data-drupal-selector="edit-localgov-destinations"] tr',
+        context,
+      );
+      linkRows.forEach((row) => {
+        row.addEventListener('dragover', (event) => {
+          const ref = row.querySelector(
+            'input[data-drupal-selector$=target-id]',
+          );
+          if (ref.value === '') {
             event.preventDefault();
-            event.dataTransfer.dropEffect = "move";
+            event.dataTransfer.dropEffect = 'move';
           }
         });
-        this.addEventListener('drop', function(event) {
-          var row = $(event.target).closest('tr');
-          var ref = $("input[data-drupal-selector$=target-id]", row);
-          if (ref.val() == '') {
+        row.addEventListener('drop', (event) => {
+          const ref = row.querySelector(
+            'input[data-drupal-selector$=target-id]',
+          );
+          if (ref.value === '') {
             event.preventDefault();
-            ref.val(dragChild.getAttribute('data-localgov-reference'));
-            $(dragChild).remove();
+            ref.value = dragChild.getAttribute('data-localgov-reference');
+            dragChild.remove();
           }
         });
       });
-    }
+    },
   };
 
   Drupal.behaviors.localgovServiceSubChildDrop = {
-    attach: function attach(context, settings) {
-      var linkRow = $("[data-drupal-selector$='-subform-topic-list-links'] tr");
-      linkRow.each(function() {
-        this.addEventListener('dragover', function (event) {
-          var row = $(event.target).closest('tr');
-          var url = $("input[data-drupal-selector$=uri]", row);
-          if (url.val() == '') {
+    attach: function attach(context) {
+      const linkRows = once(
+        'allServicesLinkRows',
+        '[data-drupal-selector$="-subform-topic-list-links"] tr',
+        context,
+      );
+      linkRows.forEach((row) => {
+        row.addEventListener('dragover', (event) => {
+          const url = row.querySelector('input[data-drupal-selector$=uri]');
+          if (url.value === '') {
             event.preventDefault();
-            event.dataTransfer.dropEffect = "move";
+            event.dataTransfer.dropEffect = 'move';
           }
         });
-        this.addEventListener('drop', function(event) {
-          var row = $(event.target).closest('tr');
-          var url = $("input[data-drupal-selector$=uri]", row);
-          if (url.val() == '') {
+        row.addEventListener('drop', (event) => {
+          const url = row.querySelector('input[data-drupal-selector$=uri]');
+          if (url.value === '') {
             event.preventDefault();
-            var title = $("input[data-drupal-selector$=title]", row);
-            title.val(dragChild.getAttribute('data-localgov-title'));
-            url.val(dragChild.getAttribute('data-localgov-url'));
-            $(dragChild).remove();
+            const title = row.querySelector(
+              'input[data-drupal-selector$=title]',
+            );
+            title.value = dragChild.getAttribute('data-localgov-title');
+            url.value = dragChild.getAttribute('data-localgov-url');
+            dragChild.remove();
           }
         });
       });
-    }
+    },
   };
 
   // Account for menus for sticky position.
-  $(document).on('drupalViewportOffsetChange', function () {
-    $('div.localgov-services-children-list.item-list').css('top', $('body').css('padding-top'));
+  document.addEventListener('drupalViewportOffsetChange', () => {
+    document.querySelector(
+      'div.localgov-services-children-list.item-list',
+    ).style.top = getComputedStyle(document.body).paddingTop;
   });
-
-})(jQuery, Drupal);
+})(Drupal, once);

--- a/modules/localgov_services_status/js/localgov-services-status.js
+++ b/modules/localgov_services_status/js/localgov-services-status.js
@@ -8,7 +8,7 @@
  * Syntax: ES5
  */
 
-/* eslint no-var: 'off', prefer-template: 'off', no-restricted-globals: 'off' */
+/* eslint no-restricted-globals: 'off' */
 (function jumpToStatusMsg(Drupal) {
   /**
    * Which status message are we after?
@@ -20,8 +20,8 @@
    *   Integer or bool.
    */
   function findTargetStatusMessageNumber() {
-    var isNum = false;
-    var statusNumber = '';
+    let isNum = false;
+    let statusNumber = '';
 
     if (!location.hash) {
       return false;
@@ -52,12 +52,12 @@
      *   Reference to window.drupalSettings.
      */
     attach(context) {
-      var statusNum = findTargetStatusMessageNumber();
+      const statusNum = findTargetStatusMessageNumber();
 
-      var tabSelector = 'a[href="#status-' + statusNum + '"]';
-      var accordionSelector = '#heading-' + statusNum + ' a';
+      const tabSelector = `a[href="#status-${statusNum}"]`;
+      const accordionSelector = `#heading-${statusNum} a`;
 
-      var isTabVisible = document.getElementById('tabs').offsetParent;
+      const isTabVisible = document.getElementById('tabs').offsetParent;
 
       if (isTabVisible) {
         jQuery(tabSelector, context).tab('show');

--- a/modules/localgov_services_status/js/localgov-services-status.js
+++ b/modules/localgov_services_status/js/localgov-services-status.js
@@ -8,7 +8,7 @@
  * Syntax: ES5
  */
 
-/* eslint no-var: "off", prefer-template: "off", no-restricted-globals: "off" */
+/* eslint no-var: 'off', prefer-template: 'off', no-restricted-globals: 'off' */
 (function jumpToStatusMsg(Drupal) {
   /**
    * Which status message are we after?
@@ -21,13 +21,13 @@
    */
   function findTargetStatusMessageNumber() {
     var isNum = false;
-    var statusNumber = "";
+    var statusNumber = '';
 
     if (!location.hash) {
       return false;
     }
 
-    statusNumber = location.hash.replace(/#status-mobile-|#status-/, "");
+    statusNumber = location.hash.replace(/#status-mobile-|#status-/, '');
 
     isNum = /\d+/.test(statusNumber);
     if (isNum) {
@@ -55,17 +55,17 @@
       var statusNum = findTargetStatusMessageNumber();
 
       var tabSelector = 'a[href="#status-' + statusNum + '"]';
-      var accordionSelector = "#heading-" + statusNum + " a";
+      var accordionSelector = '#heading-' + statusNum + ' a';
 
-      var isTabVisible = document.getElementById("tabs").offsetParent;
+      var isTabVisible = document.getElementById('tabs').offsetParent;
 
       if (isTabVisible) {
-        jQuery(tabSelector, context).tab("show");
+        jQuery(tabSelector, context).tab('show');
       } else {
         // The Bootstrap collapse() method is giving inconsistent results in
         // some cases.  So directly clicking the Accordion header.
         jQuery(accordionSelector, context).click();
       }
-    }
+    },
   };
 })(Drupal);


### PR DESCRIPTION
Closes #321

## What does this change?

1. Rewrites our services JS to remove jQuery and use vanilla JS
2. Fixing coding standards

We need to get this merged so our tests will start passing again.

## How to test

Add a service page, set a parent for it, go to the parent page and check that you can still use the drag 'n' drop feature to drag the page to the 'child pages' field.

## How can we measure success?

Our tests pass and continue to pass.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.