### PR TITLE
Delete action for a Service Landing page or Service Sub Landing Page can trigger a PHP error.

### DIFF
--- a/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
+++ b/modules/localgov_services_navigation/src/EntityChildRelationshipUi.php
@@ -139,8 +139,16 @@ class EntityChildRelationshipUi implements ContainerInjectionInterface {
       $form['localgov_services_navigation_children'] = [
         '#items' => $this->childrenField($node),
         '#theme' => 'item_list',
-        '#wrapper_attributes' => ['class' => 'localgov-services-children-list'],
-        '#attached' => ['library' => 'localgov_services_navigation/children'],
+        '#wrapper_attributes' => [
+          'class' => [
+            'localgov-services-children-list'
+          ]
+        ],
+        '#attached' => [
+          'library' => [
+            'localgov_services_navigation/children'
+          ]
+        ],
         '#title' => $this->t('Pages linking here'),
       ];
     }


### PR DESCRIPTION
## What does this change?
The PR fix the definition of 

- $form['localgov_services_navigation_children']['#wrapper_attributes']['class']
- $form['localgov_services_navigation_children']['#attached']['library']

They must be array of string, not string.
## How to test

1. Open Content page
2. select any Service Landing page or a  Service  Sub Landing Page
3. Try to delete the content from the Operations dropdown.
4. The confirmation Modal should be shown regularly without any error.

## How can we measure success?
The error message "Oops, something went wrong. Check your browser's developer console for more details." Is not shown and the confirmation dialog is shown.

## Have we considered potential risks?
No risks, it's a simple coding issue.

## Related Issue
https://github.com/localgovdrupal/localgov_services/issues/328