### PR TITLE
Fix/2.x/335 path alias

### DIFF
--- a/config/install/pathauto.pattern.localgov_services_hierarchy.yml
+++ b/config/install/pathauto.pattern.localgov_services_hierarchy.yml
@@ -6,7 +6,7 @@ dependencies:
 id: localgov_services_hierarchy
 label: 'Services Hierarchy'
 type: 'canonical_entities:node'
-pattern: '[node:localgov_services_parent:entity:url:relative]/[node:title]'
+pattern: '[node:localgov_services_parent:entity:url:path]/[node:title]'
 selection_criteria:
   9dd1b1bc-3678-4642-8568-86d6d27c3dfd:
     id: 'entity_bundle:node'

--- a/localgov_services.post_update.php
+++ b/localgov_services.post_update.php
@@ -1,0 +1,22 @@
+<?php
+
+use Drupal\pathauto\Entity\PathautoPattern;
+use Drupal\pathauto\PathautoPatternInterface;
+
+/**
+ * @file
+ * Post update functions for LocalGov Services.
+ */
+
+/**
+ * Update pathauto patterns to avoid inclusion of subdirectory, language, etc.
+ */
+function localgov_services_post_update_pathauto_parent(): void {
+  $alias = PathautoPattern::load('localgov_services_hierarchy');
+  if ($alias instanceof PathautoPatternInterface &&
+    $alias->getPattern() == '[node:localgov_services_parent:entity:url:relative]/[node:title]'
+  ) {
+    $alias->setPattern('[node:localgov_services_parent:entity:url:path]/[node:title]');
+    $alias->save();
+  }
+}

--- a/localgov_services.post_update.php
+++ b/localgov_services.post_update.php
@@ -1,12 +1,12 @@
 <?php
 
-use Drupal\pathauto\Entity\PathautoPattern;
-use Drupal\pathauto\PathautoPatternInterface;
-
 /**
  * @file
  * Post update functions for LocalGov Services.
  */
+
+use Drupal\pathauto\Entity\PathautoPattern;
+use Drupal\pathauto\PathautoPatternInterface;
 
 /**
  * Update pathauto patterns to avoid inclusion of subdirectory, language, etc.

--- a/modules/localgov_services_navigation/localgov_services_navigation.module
+++ b/modules/localgov_services_navigation/localgov_services_navigation.module
@@ -65,8 +65,8 @@ function localgov_services_navigation_pathauto_pattern_alter(PathautoPattern $pa
   // it has opt-ed in with the field add the (optional) parent to the path.
   $entity = reset($context['data']);
   assert($entity instanceof ContentEntityInterface);
-  if ($entity->hasField('localgov_services_parent') && strpos($pattern->getPattern(), '[node:localgov_services_parent:entity:url:relative]') === FALSE) {
-    $pattern->setPattern('[node:localgov_services_parent:entity:url:relative]/' . $pattern->getPattern());
+  if ($entity->hasField('localgov_services_parent') && strpos($pattern->getPattern(), '[node:localgov_services_parent:entity:url:path]') === FALSE) {
+    $pattern->setPattern('[node:localgov_services_parent:entity:url:path]/' . $pattern->getPattern());
   }
 }
 

--- a/modules/localgov_services_status/config/optional/pathauto.pattern.localgov_service_status.yml
+++ b/modules/localgov_services_status/config/optional/pathauto.pattern.localgov_service_status.yml
@@ -6,7 +6,7 @@ dependencies:
 id: localgov_service_status
 label: 'Service Status Page'
 type: 'canonical_entities:node'
-pattern: '[node:localgov_services_parent:entity:url:relative]/status/[node:title]'
+pattern: '[node:localgov_services_parent:entity:url:path]/status/[node:title]'
 selection_criteria:
   fb899c5a-41f3-4482-9b7d-7f203c4290c4:
     id: 'entity_bundle:node'

--- a/modules/localgov_services_status/localgov_services_status.post_update.php
+++ b/modules/localgov_services_status/localgov_services_status.post_update.php
@@ -1,0 +1,22 @@
+<?php
+
+use Drupal\pathauto\Entity\PathautoPattern;
+use Drupal\pathauto\PathautoPatternInterface;
+
+/**
+ * @file
+ * Post update functions for LocalGov Services Status.
+ */
+
+/**
+ * Update pathauto patterns to avoid inclusion of subdirectory, language, etc.
+ */
+function localgov_services_status_post_update_pathauto_parent(): void {
+  $alias = PathautoPattern::load('localgov_service_status');
+  if ($alias instanceof PathautoPatternInterface &&
+    $alias->getPattern() == '[node:localgov_services_parent:entity:url:relative]/status/[node:title]'
+  ) {
+    $alias->setPattern('[node:localgov_services_parent:entity:url:path]/status/[node:title]');
+    $alias->save();
+  }
+}

--- a/modules/localgov_services_status/localgov_services_status.post_update.php
+++ b/modules/localgov_services_status/localgov_services_status.post_update.php
@@ -1,12 +1,12 @@
 <?php
 
-use Drupal\pathauto\Entity\PathautoPattern;
-use Drupal\pathauto\PathautoPatternInterface;
-
 /**
  * @file
  * Post update functions for LocalGov Services Status.
  */
+
+use Drupal\pathauto\Entity\PathautoPattern;
+use Drupal\pathauto\PathautoPatternInterface;
 
 /**
  * Update pathauto patterns to avoid inclusion of subdirectory, language, etc.


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Fixes prefixes (subdirectory, language) being included in parent path pattern for other instances.
    
See https://github.com/localgovdrupal/localgov_services/issues/335#issuecomment-3461396195

## How to test

Set up site, or upgrade site, with multilingual and/or in a subdirectory. Create services, sub landing and pages. The paths should be correct and not repeat the language or subdirectory prefix to the path.

Present tests should continue to pass :crossed_fingers: if we want to test against this regressing then we'll have to start maybe adding multilingual tests (not such a bad idea).